### PR TITLE
add an API function for versioning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,5 @@
+Change log
+==========
+
+This is just a place holder for now until the first official release. Until
+then, refer to the Git commit log for changes.

--- a/libclink/CMakeLists.txt
+++ b/libclink/CMakeLists.txt
@@ -30,7 +30,22 @@ add_library(libclink
   src/symbol.c
   src/temp_dir.c
   src/vim_highlight.c
-  src/vim_open.c)
+  src/vim_open.c
+  ${CMAKE_CURRENT_BINARY_DIR}/version.c)
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+add_custom_command(
+  OUTPUT version.c
+  COMMAND src/make-version.py ${CMAKE_CURRENT_BINARY_DIR}/version.c
+  MAIN_DEPENDENCY src/make-version.py
+  DEPENDS always_run
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+# dummy output to make sure we always re-evaluate the version step above
+add_custom_command(
+  OUTPUT always_run
+  COMMAND /usr/bin/env true)
 
 target_include_directories(libclink
   PUBLIC

--- a/libclink/include/clink/clink.h
+++ b/libclink/include/clink/clink.h
@@ -5,4 +5,5 @@
 #include <clink/db.h>
 #include <clink/iter.h>
 #include <clink/symbol.h>
+#include <clink/version.h>
 #include <clink/vim.h>

--- a/libclink/include/clink/version.h
+++ b/libclink/include/clink/version.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** retrieve version of this library
+ *
+ * For now, the version of Clink is an opaque string. You cannot use it to
+ * determine whether one version is newer than another. The most you can do is
+ * `strcmp` two version strings to determine if they are the same.
+ *
+ * \return A version string
+ */
+const char *clink_version(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libclink/src/make-version.py
+++ b/libclink/src/make-version.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+"""
+Generate contents of a version.c.
+"""
+
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess as sp
+import sys
+from typing import Optional
+
+def last_release() -> str:
+  """
+  The version of the last release. This will be used as the version number if no
+  Git information is available.
+  """
+  with open(Path(__file__).parent / "../../CHANGELOG.rst", "rt") as f:
+    for line in f:
+      m = re.match(r"(v\d{4}\.\d{2}\.\d{2})$", line)
+      if m is not None:
+        return m.group(1)
+
+  return "<unknown>"
+
+def has_git() -> bool:
+  """
+  Return True if we are in a Git repository and have Git.
+  """
+
+  # return False if we don't have Git
+  if shutil.which("git") is None:
+    return False
+
+  # return False if we have no Git repository information
+  if not (Path(__file__).parent / "../../.git").exists():
+    return False
+
+  return True
+
+def get_tag() -> Optional[str]:
+  """
+  Find the version tag of the current Git commit, e.g. v2020.05.03, if it
+  exists.
+  """
+  try:
+    tag = sp.check_output(["git", "describe", "--tags"], stderr=sp.DEVNULL)
+  except sp.CalledProcessError:
+    tag = None
+
+  if tag is not None:
+    tag = tag.decode("utf-8", "replace").strip()
+    if re.match(r"v[\d\.]+$", tag) is None:
+      # not a version tag
+      tag = None
+
+  return tag
+
+def get_sha() -> str:
+  """
+  Find the hash of the current Git commit.
+  """
+  rev = sp.check_output(["git", "rev-parse", "--verify", "HEAD"])
+  rev = rev.decode("utf-8", "replace").strip()
+
+  return rev
+
+def is_dirty() -> bool:
+  """
+  Determine whether the current working directory has uncommitted changes.
+  """
+  dirty = False
+
+  p = sp.run(["git", "diff", "--exit-code"], stdout=sp.DEVNULL,
+    stderr=sp.DEVNULL)
+  dirty |= p.returncode != 0
+
+  p = sp.run(["git", "diff", "--cached", "--exit-code"], stdout=sp.DEVNULL,
+    stderr=sp.DEVNULL)
+  dirty |= p.returncode != 0
+
+  return dirty
+
+def main(args: [str]) -> int:
+
+  if len(args) != 2 or args[1] == "--help":
+    sys.stderr.write(
+      f"usage: {args[0]} file\n"
+       " write version information as a C source file\n")
+    return -1
+
+  # get the contents of the old version file if it exists
+  old = None
+  if os.path.exists(args[1]):
+    with open(args[1], "rt") as f:
+      old = f.read()
+
+  version = None
+
+  # look for a version tag on the current commit
+  if version is None and has_git():
+    tag = get_tag()
+    if tag is not None:
+      version = f'{tag}{" (dirty)" if is_dirty() else ""}'
+
+  # look for the commit hash as the version
+  if version is None and has_git():
+    rev = get_sha()
+    assert rev is not None
+    version = f'Git commit {rev}{" (dirty)" if is_dirty() else ""}'
+
+  # fall back to our known release version
+  if version is None:
+    version = last_release()
+
+  new =  '#include <clink/version.h>\n' \
+         '\n' \
+         'const char *clink_version(void) {\n' \
+        f'  return "{version}";\n' \
+         '}'
+
+  # If the version has changed, update the output. Otherwise we leave the old
+  # contents – and more importantly, the timestamp – intact.
+  if old != new:
+    with open(args[1], "wt") as f:
+      f.write(new)
+
+  return 0
+
+if __name__ == "__main__":
+  sys.exit(main(sys.argv))


### PR DESCRIPTION
This adds a versioning mechanism based on that from Rumur¹ that has served us
well for years. This incurs a Python ≥3.6 dependency, but it is assumed this is
not a problem for anyone who already has libclang available. This side steps a
couple of issues with the Rumur implementation of this. In particular, the
version is generated in a source file rather than a header to avoid:

  1. Every build of a new Git commit updating version.h causing a complete
     rebuild of anything including this file; and

  2. Versioning being available in a header confusing client programs that have
     an inconsistent include vs link path, causing them to think they have one
     version of the library when they are really linking against another.

¹ https://github.com/smattr/rumur