### PR TITLE
one-shot parse C/C++ instead of iteratively

### DIFF
--- a/clink/src/build.c
+++ b/clink/src/build.c
@@ -170,42 +170,42 @@ static int process(unsigned long thread_id, pthread_t *threads, clink_db_t *db,
           break;
         }
 
-        clink_iter_t *it = NULL;
-
         // assembly
         if (is_asm(t.path)) {
+
+          clink_iter_t *it = NULL;
           progress(thread_id, "parsing asm file %s", display);
           rc = clink_parse_asm(&it, t.path);
+
+          if (rc == 0) {
+            // parse all symbols and add them to the database
+            while (true) {
+
+              const clink_symbol_t *symbol = NULL;
+              if ((rc = clink_iter_next_symbol(it, &symbol))) {
+                if (LIKELY(rc == ENOMSG)) // exhausted iterator
+                  rc = 0;
+                break;
+              }
+              assert(symbol != NULL);
+
+              DEBUG("adding symbol %s:%lu:%lu:%s", symbol->path, symbol->lineno,
+                symbol->colno, symbol->name);
+              if (UNLIKELY((rc = clink_db_add_symbol(db, symbol))))
+                break;
+            }
+          }
+
+          clink_iter_free(&it);
 
         // C/C++
         } else {
           assert(is_c(t.path));
           progress(thread_id, "parsing C/C++ file %s", display);
           const char **argv = (const char**)option.cxx_argv;
-          rc = clink_parse_c(&it, t.path, option.cxx_argc, argv);
+          rc = clink_parse_c_into(db, t.path, option.cxx_argc, argv);
 
         }
-
-        if (rc == 0) {
-          // parse all symbols and add them to the database
-          while (true) {
-
-            const clink_symbol_t *symbol = NULL;
-            if ((rc = clink_iter_next_symbol(it, &symbol))) {
-              if (LIKELY(rc == ENOMSG)) // exhausted iterator
-                rc = 0;
-              break;
-            }
-            assert(symbol != NULL);
-
-            DEBUG("adding symbol %s:%lu:%lu:%s", symbol->path, symbol->lineno,
-              symbol->colno, symbol->name);
-            if (UNLIKELY((rc = clink_db_add_symbol(db, symbol))))
-              break;
-          }
-        }
-
-        clink_iter_free(&it);
 
         if (UNLIKELY(rc))
           error(thread_id, "failed to parse %s: %s", display, strerror(rc));

--- a/libclink/include/clink/c.h
+++ b/libclink/include/clink/c.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <clink/db.h>
 #include <clink/iter.h>
 #include <stddef.h>
 
@@ -21,6 +22,23 @@ extern "C" {
  */
 CLINK_API int clink_parse_c(clink_iter_t **it, const char *filename,
                             size_t argc, const char **argv);
+
+/**
+ * parse the given C/C++ file, inserting results into the given database
+ *
+ * This function is provided as an alternative to `clink_parse_c` for when the
+ * action being done with every result is simply to insert it into a Clink
+ * database. This function avoids the overhead of constructing and managing
+ * iterator state.
+ *
+ * \param db Database to insert into
+ * \param filename Path to source file to parse
+ * \param argc Number of elements in argv
+ * \param argv Arguments to pass to Clang
+ * \returns 0 on success or an errno on failure
+ */
+CLINK_API int clink_parse_c_into(clink_db_t *db, const char *filename,
+                                 size_t argc, const char **argv);
 
 /** get the built-in list of #include paths the compiler knows
  *

--- a/libclink/src/parse_c.c
+++ b/libclink/src/parse_c.c
@@ -42,11 +42,11 @@ typedef struct {
   /// status of our Clang traversal (0 OK, non-zero on error)
   int rc;
 
-} state_t;
+} iter_state_t;
 
-static void state_free(state_t **s) {
+static void state_free(iter_state_t **s) {
 
-  state_t *ss = *s;
+  iter_state_t *ss = *s;
 
   if (ss == NULL)
     return;
@@ -77,7 +77,7 @@ static void state_free(state_t **s) {
 
 static int push_cursor(void *state, CXCursor cursor) {
 
-  state_t *s = state;
+  iter_state_t *s = state;
 
   assert(s != NULL);
 
@@ -172,7 +172,7 @@ static int push_cursor(void *state, CXCursor cursor) {
   return s->rc;
 }
 
-static node_t pop_cursor(state_t *s) {
+static node_t pop_cursor(iter_state_t *s) {
 
   assert(s != NULL);
   assert(s->pending_size > 0);
@@ -193,7 +193,7 @@ static node_t pop_cursor(state_t *s) {
 static int push_symbol(void *state, clink_category_t category, const char *name,
     const char *path, unsigned lineno, unsigned colno) {
 
-  state_t *s = state;
+  iter_state_t *s = state;
 
   assert(s != NULL);
 
@@ -254,7 +254,7 @@ done:
   return s->rc;
 }
 
-static void pop_symbol(state_t *s) {
+static void pop_symbol(iter_state_t *s) {
 
   assert(s != NULL);
 
@@ -408,7 +408,7 @@ static enum CXChildVisitResult visit_iter(CXCursor cursor, CXCursor parent,
 }
 
 /// expand a pending cursor and add more entries to the next queue
-static int expand(state_t *s) {
+static int expand(iter_state_t *s) {
 
   assert(s != NULL);
   assert(s->pending_size > 0);
@@ -438,7 +438,7 @@ static int next(clink_iter_t *it, const clink_symbol_t **yielded) {
   if (UNLIKELY(yielded == NULL))
     return EINVAL;
 
-  state_t *s = it->state;
+  iter_state_t *s = it->state;
 
   if (UNLIKELY(s == NULL))
     return EINVAL;
@@ -472,7 +472,7 @@ static void my_free(clink_iter_t *it) {
   if (it->state == NULL)
     return;
 
-  state_free((state_t**)&it->state);
+  state_free((iter_state_t**)&it->state);
 }
 
 // translate a libclang error into the closest errno equivalent
@@ -503,7 +503,7 @@ int clink_parse_c(clink_iter_t **it, const char *filename, size_t argc,
     return errno;
 
   // allocate iterator state
-  state_t *s = calloc(1, sizeof(*s));
+  iter_state_t *s = calloc(1, sizeof(*s));
   if (UNLIKELY(s == NULL))
     return ENOMEM;
 

--- a/libclink/src/parse_c.c
+++ b/libclink/src/parse_c.c
@@ -44,6 +44,13 @@ typedef struct {
 
 } iter_state_t;
 
+static void deinit(CXTranslationUnit tu, CXIndex index) {
+  if (tu != NULL)
+    clang_disposeTranslationUnit(tu);
+
+  clang_disposeIndex(index);
+}
+
 static void state_free(iter_state_t **s) {
 
   iter_state_t *ss = *s;
@@ -65,11 +72,8 @@ static void state_free(iter_state_t **s) {
   ss->pending = NULL;
   ss->pending_size = ss->pending_capacity = 0;
 
-  if (ss->tu != NULL)
-    clang_disposeTranslationUnit(ss->tu);
+  deinit(ss->tu, ss->index);
   ss->tu = NULL;
-
-  clang_disposeIndex(ss->index);
 
   free(ss);
   *s = NULL;


### PR DESCRIPTION
This swaps the way C/C++ are parsed to a more efficient technique that inserts results directly into the database as they are found. Empirically this is a noticeable speed up when parsing large files.