### PR TITLE
enable compiler’s system include directories by default

### DIFF
--- a/clink/src/option.h
+++ b/clink/src/option.h
@@ -50,5 +50,23 @@ int set_db_path(void);
 // setup option.src after option parsing
 int set_src(void);
 
+/** setup flags for the C++ compiler
+ *
+ * This function assumes the caller wants system include directories enabled
+ * (as if `-nostdinc` was not supplied). This may change in future.
+ *
+ * None of the data of the input array’s entries are modified, but the input
+ * array’s entries themselves may be modified by taking ownership of their
+ * memory and overwriting them with NULL. On success or failure, the caller
+ * should assume they can do nothing with this array except free it and all its
+ * entries.
+ *
+ * \param includes An array of paths to be passed to the compiler with the `-I`
+ *   option.
+ * \param includes_len The length of `includes`.
+ * \return 0 on success or an errno on failure.
+ */
+int set_cxx_flags(char **includes, size_t includes_len);
+
 // deallocate members of option
 void clean_up_options(void);


### PR DESCRIPTION
When building the database, the compiler’s own known system paths would
previously not be used. The effect of this was that parsing, by default, could
not locate system headers like stdlib.h and had incomplete information when
doing semantic analysis, leading to inaccurate or missing results. The work
around for this was to explicitly pass the system paths to `clink` with
`--include`/`-I`.

While this led to reasonable results, it is simpler for both users and Clink
itself to just ask the compiler what its known system include paths are. This is
what this change adds. These system paths are now passed to the compiler using
`-isystem` prior to the user’s include paths.

In future, `clink` will probably have to grow a `-nostdinc` option to do the
equivalent of `cscope` “kernel mode.”