### PR TITLE
implement VCS mode

### DIFF
--- a/clink/src/clink.1
+++ b/clink/src/clink.1
@@ -24,8 +24,13 @@ stdout is a TTY).
 .RS
 Open or create the symbol database at path \fIFILE\fR. Without this option,
 Clink will default to opening the file .clink.db in the current directory or any
-parent thereof if it exists. If none of these exist, Clink will fallback
-to .clink.db in the current directory.
+parent thereof if it exists. It will stop its search when it reaches the root of
+a Git, Mercurial, or Subversion checkout, under the assumption that you do not
+wish to index beyond the boundary of a repository you are in.
+.PP
+If no repository root is found, the search will stop when reaching the root
+directory of the file system, at which point Clink will fallback to .clink.db in
+the current directory.
 .RE
 .PP
 \fB--debug\fR

--- a/clink/src/option.c
+++ b/clink/src/option.c
@@ -59,6 +59,28 @@ int set_db_path(void) {
       goto done;
     }
 
+    // is this the root of a repository checkout?
+    // TODO: support Git Worktrees?
+    static const char *VCS_DIR[] = {".git", ".hg", ".svn"};
+    for (size_t i = 0; i < sizeof(VCS_DIR) / sizeof(VCS_DIR[0]); i++) {
+
+      // derive the candidate repository metadata dir
+      char *vcs_dir = NULL;
+      if ((rc = join(branch, VCS_DIR[i], &vcs_dir))) {
+        free(candidate);
+        goto done;
+      }
+
+      // if it exists, use an adjacent database
+      if (access(vcs_dir, F_OK) == 0) {
+        free(vcs_dir);
+        option.database_path = candidate;
+        goto done;
+      }
+
+      free(vcs_dir);
+    }
+
     free(candidate);
 
     // if we just checked the file system root, give up


### PR DESCRIPTION
As described in the man page, this implements some additional logic in the
database location search that attempts to figure out the likely place the user
wants to root their symbol database. This side steps the common problem of being
in a repository checkout, running `cscope -R`, and then realising you have only
access to your current directory and below.

Github: closes #13, “vcs mode”