### PR TITLE
fix '--help' on Linux

### DIFF
--- a/clink/src/help.c
+++ b/clink/src/help.c
@@ -70,7 +70,7 @@ int help(void) {
   {
     const char *argv[] = {"man",
 #ifdef __linux__
-                          "--local-file ",
+                          "--local-file",
 #endif
                           path, NULL};
     char *const *args = (char *const *)argv;


### PR DESCRIPTION
When replicating this mechanism from Rumur,
46f92cea1881f1e01823fb9f08371cc244010fb8 failed to realise the Rumur code is
constructing a string command line for `system`, hence why it had a trailing
space in "--local-file ".

Github: fixes #105 “clink --help doesn't work on Fedora 36”