### PR TITLE
leave spinner visible while processing results

### DIFF
--- a/clink/src/ncurses_ui.c
+++ b/clink/src/ncurses_ui.c
@@ -115,6 +115,15 @@ static const size_t FUNCTIONS_SZ = sizeof(functions) / sizeof(functions[0]);
 
 static int format_results(clink_iter_t *it) {
 
+  // note to the user what we are doing
+  {
+    size_t rows = screen_get_rows();
+    move(rows - FUNCTIONS_SZ, 1);
+    PRINT("   formatting results…");
+    clrtoeol();
+    (void)spinner_on(rows - FUNCTIONS_SZ, 2);
+  }
+
   // free any previous results
   for (size_t i = 0; i < results.count; ++i)
     clink_symbol_clear(&results.rows[i]);
@@ -179,18 +188,23 @@ static int format_results(clink_iter_t *it) {
       const char *path = target->path;
       int r = set_add(highlighted, &path);
       if (r == 0) {
-        // note to the user what we are doing
+        // update what we are doing
+        spinner_off();
         size_t rows = screen_get_rows();
-        move(rows - FUNCTIONS_SZ, 1);
-        PRINT("   syntax highlighting %s…", target->path);
+        move(rows - FUNCTIONS_SZ, 4);
+        PRINT("syntax highlighting %s…", target->path);
+        clrtoeol();
         (void)spinner_on(rows - FUNCTIONS_SZ, 2);
 
         // ignore non-fatal failure of highlighting
         (void)clink_vim_read_into(database, target->path);
 
+        // update what we are doing
         spinner_off();
-        move(rows - FUNCTIONS_SZ, 1);
+        move(rows - FUNCTIONS_SZ, 4);
+        PRINT("formatting results…");
         clrtoeol();
+        (void)spinner_on(rows - FUNCTIONS_SZ, 2);
       } else if (r != EALREADY) {
         rc = r;
         break;
@@ -222,6 +236,13 @@ static int format_results(clink_iter_t *it) {
   }
 
 done:
+
+  spinner_off();
+  {
+    size_t rows = screen_get_rows();
+    move(rows - FUNCTIONS_SZ, 1);
+    clrtoeol();
+  }
 
   set_free(&highlighted);
   clink_iter_free(&it);

--- a/clink/src/ncurses_ui.c
+++ b/clink/src/ncurses_ui.c
@@ -92,7 +92,7 @@ static void move(size_t row, size_t column) {
   PRINT("\033[%zu;%zuH", row, column);
 }
 
-static void clrtoeol(void) { PRINT("\033[K"); }
+static const char CLRTOEOL[] = "\033[K";
 
 static int find_symbol(const char *query);
 static int find_definition(const char *query);
@@ -119,8 +119,7 @@ static int format_results(clink_iter_t *it) {
   {
     size_t rows = screen_get_rows();
     move(rows - FUNCTIONS_SZ, 1);
-    PRINT("   formatting results…");
-    clrtoeol();
+    PRINT("   formatting results…%s", CLRTOEOL);
     (void)spinner_on(rows - FUNCTIONS_SZ, 2);
   }
 
@@ -192,8 +191,7 @@ static int format_results(clink_iter_t *it) {
         spinner_off();
         size_t rows = screen_get_rows();
         move(rows - FUNCTIONS_SZ, 4);
-        PRINT("syntax highlighting %s…", target->path);
-        clrtoeol();
+        PRINT("syntax highlighting %s…%s", target->path, CLRTOEOL);
         (void)spinner_on(rows - FUNCTIONS_SZ, 2);
 
         // ignore non-fatal failure of highlighting
@@ -202,8 +200,7 @@ static int format_results(clink_iter_t *it) {
         // update what we are doing
         spinner_off();
         move(rows - FUNCTIONS_SZ, 4);
-        PRINT("formatting results…");
-        clrtoeol();
+        PRINT("formatting results…%s", CLRTOEOL);
         (void)spinner_on(rows - FUNCTIONS_SZ, 2);
       } else if (r != EALREADY) {
         rc = r;
@@ -241,7 +238,7 @@ done:
   {
     size_t rows = screen_get_rows();
     move(rows - FUNCTIONS_SZ, 1);
-    clrtoeol();
+    PRINT("%s", CLRTOEOL);
   }
 
   set_free(&highlighted);
@@ -396,7 +393,7 @@ static int print_results(void) {
     size_t padding = widths[i] - strlen(HEADINGS[i]);
     pad(padding);
   }
-  clrtoeol();
+  PRINT("%s", CLRTOEOL);
 
   // print the rows
   for (size_t i = 0; i < rows - FUNCTIONS_SZ - 1 - 1; ++i) {
@@ -430,7 +427,7 @@ static int print_results(void) {
         }
       }
     }
-    clrtoeol();
+    PRINT("%s", CLRTOEOL);
   }
 
   // print footer
@@ -448,8 +445,7 @@ static int print_results(void) {
       PRINT(", press the space bar to display the first lines again");
     }
   }
-  PRINT(" *");
-  clrtoeol();
+  PRINT(" *%s", CLRTOEOL);
 
   return 0;
 }
@@ -498,7 +494,7 @@ static void move_to_line(size_t target) {
 
   // blank the current line
   move(y, offset_x(prompt_index));
-  clrtoeol();
+  PRINT("%s", CLRTOEOL);
 
   move_to_line_no_blank(target);
 }

--- a/clink/src/ncurses_ui.c
+++ b/clink/src/ncurses_ui.c
@@ -187,21 +187,19 @@ static int format_results(clink_iter_t *it) {
       const char *path = target->path;
       int r = set_add(highlighted, &path);
       if (r == 0) {
-        // update what we are doing
-        spinner_off();
+        // Update what we are doing. Inline the move and `CLRTOEOL` so we can do
+        // it all while holding the stdout lock and avoid racing with the
+        // spinner.
         size_t rows = screen_get_rows();
-        move(rows - FUNCTIONS_SZ, 4);
-        PRINT("syntax highlighting %s…%s", target->path, CLRTOEOL);
-        (void)spinner_on(rows - FUNCTIONS_SZ, 2);
+        PRINT("\033[%zu;4Hsyntax highlighting %s…%s", rows - FUNCTIONS_SZ,
+              target->path, CLRTOEOL);
 
         // ignore non-fatal failure of highlighting
         (void)clink_vim_read_into(database, target->path);
 
         // update what we are doing
-        spinner_off();
-        move(rows - FUNCTIONS_SZ, 4);
-        PRINT("formatting results…%s", CLRTOEOL);
-        (void)spinner_on(rows - FUNCTIONS_SZ, 2);
+        PRINT("\033[%zu;4Hformatting results…%s", rows - FUNCTIONS_SZ,
+              CLRTOEOL);
       } else if (r != EALREADY) {
         rc = r;
         break;

--- a/clink/src/spinner.c
+++ b/clink/src/spinner.c
@@ -45,12 +45,16 @@ static void *spin(void *ignored __attribute__((unused))) {
         break;
     }
 
+    // prevent anyone else interleaving stdout writes with us
+    flockfile(stdout);
+
     // move to where the progress spinner should go
     printf("\033[%zu;%zuH", spinner_row, spinner_column);
 
     // output the spinner itself
     printf("%s", STATES[state]);
     fflush(stdout);
+    funlockfile(stdout);
 
     state = (state + 1) % (sizeof(STATES) / sizeof(STATES[0]));
   }


### PR DESCRIPTION
This leads to more natural behaviour for the user, where the spinner appears to be charting the progress of _all_ syntax highlighting operations and results processing.