### PR TITLE
squash -Wunused-parameter warning in release mode

### DIFF
--- a/libclink/src/re_sqlite.c
+++ b/libclink/src/re_sqlite.c
@@ -9,6 +9,7 @@ void re_sqlite(sqlite3_context *context, int argc, sqlite3_value **argv) {
 
   assert(context != NULL);
   assert(argc == 2);
+  (void)argc;
   assert(argv != NULL);
 
   const char *pattern = (const char *)sqlite3_value_text(argv[0]);


### PR DESCRIPTION
Github: #122 “build warnings with GCC 8.3.0”