### PR TITLE
CI: fix release build job not doing a release build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,6 +12,7 @@ task:
         CFLAGS: -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=undefined
         UBSAN_OPTIONS: print_stacktrace=1
       install_script: pkg upgrade -y && pkg install -y cmake git llvm py39-pytest vim
+      test_script: uname -sr && git submodule init && git submodule update && mkdir build && cd build && cmake .. && cmake --build . && cmake --build . -- check && cmake --build . -- install
 
     - name: Linux
       container:
@@ -23,6 +24,7 @@ task:
         PATH: /opt/cmake-3.21.1-linux-x86_64/bin:${PATH}
         UBSAN_OPTIONS: print_stacktrace=1
       install_script: apt-get update -y && apt-get install --no-install-recommends -y libclang-dev llvm python3-pytest sqlite3 xxd vim && wget https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1-linux-x86_64.tar.gz && mkdir -p /opt && tar xvf cmake-3.21.1-linux-x86_64.tar.gz --directory /opt
+      test_script: uname -sr && git submodule init && git submodule update && mkdir build && cd build && cmake .. && cmake --build . && cmake --build . -- check && cmake --build . -- install
 
     - name: Linux, release build
       container:
@@ -44,5 +46,4 @@ task:
         PATH: /usr/local/opt/llvm/bin:${PATH}
         UBSAN_OPTIONS: print_stacktrace=1
       install_script: brew update && brew install llvm && pip3 install pytest
-
-  test_script: uname -sr && git submodule init && git submodule update && mkdir build && cd build && cmake .. && cmake --build . && cmake --build . -- check && cmake --build . -- install
+      test_script: uname -sr && git submodule init && git submodule update && mkdir build && cd build && cmake .. && cmake --build . && cmake --build . -- check && cmake --build . -- install


### PR DESCRIPTION
It seems having a local `test_script` for one element of the matrix does not override the top level `test_script` as I had been expecting.