### PR TITLE
show a better error message when Vim is not found

### DIFF
--- a/clink/CMakeLists.txt
+++ b/clink/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(clink
   src/dirname.c
   src/disppath.c
   src/file_queue.c
+  src/have_vim.c
   src/help.c
   src/is_root.c
   src/join.c

--- a/clink/src/have_vim.c
+++ b/clink/src/have_vim.c
@@ -1,0 +1,7 @@
+#include "have_vim.h"
+#include <stdbool.h>
+#include <stdlib.h>
+
+bool have_vim(void) {
+  return system("which vim >/dev/null 2>/dev/null") == EXIT_SUCCESS;
+}

--- a/clink/src/have_vim.h
+++ b/clink/src/have_vim.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <stdbool.h>
+
+/// is \p vim available?
+bool have_vim(void);

--- a/clink/src/main.c
+++ b/clink/src/main.c
@@ -1,5 +1,6 @@
 #include "../../common/compiler.h"
 #include "build.h"
+#include "have_vim.h"
 #include "help.h"
 #include "ncurses_ui.h"
 #include "option.h"
@@ -314,6 +315,13 @@ int main(int argc, char **argv) {
         goto done;
       }
     }
+  }
+
+  // check we have Vim
+  if (!have_vim()) {
+    rc = ENOENT;
+    fprintf(stderr, "Vim not found\n");
+    goto done;
   }
 
   if (option.update_database) {


### PR DESCRIPTION
Replicating code that is already in Vimcat is not ideal, but it seems cleaner than reaching through Libclink to get to it.

Github: closes #79 “better error message when vim not found”