### PR TITLE
squash -Wunused-result warning for 'chdir' call

### DIFF
--- a/test/test_mkdtemp.c
+++ b/test/test_mkdtemp.c
@@ -8,7 +8,12 @@ static void my_rmdir(void *arg) {
   assert(access(arg, F_OK) == 0);
 
   // in case we are inside the directory, move elsewhere so we can remove it
-  (void)chdir("/");
+  {
+    int rc = chdir("/");
+
+    // nothing reasonable to do if `chdir` fails
+    (void)rc;
+  }
 
   (void)rmdir(arg);
 }


### PR DESCRIPTION
Later versions of Glibc have `chdir` tagged with `warn_unused_result`, making the compiler complain about our usage here.