### PR TITLE
CI: move macOS testing to Ventura on an M1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,13 +40,13 @@ task:
       test_script: ./misc/ci.sh
 
     - name: macOS
-      osx_instance:
-        image: monterey-xcode-13.3
+      macos_instance:
+        image: ghcr.io/cirruslabs/macos-ventura-base:latest
       environment:
         CFLAGS: -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=undefined
-        PATH: /usr/local/opt/llvm/bin:${PATH}
+        PATH: /opt/homebrew/opt/llvm/bin:${PATH}
         UBSAN_OPTIONS: print_stacktrace=1
-      install_script: brew update && brew install llvm && pip3 install pytest
+      install_script: brew update && brew install llvm && /opt/homebrew/Frameworks/Python.framework/Versions/3.11/bin/pip3 install pytest
       test_script: ./misc/ci.sh
 
     - name: C formatting

--- a/misc/ci.sh
+++ b/misc/ci.sh
@@ -14,5 +14,12 @@ cmake ..
 cmake --build .
 cmake --build . -- check
 printf "find-me says: "
-./test/find-me/find-me 
-cmake --build . -- install
+./test/find-me/find-me
+
+if [ "$(uname -s)" = "Darwin" ]; then
+  SUDO=sudo
+else
+  # sudo not needed
+  SUDO=
+fi
+${SUDO} cmake --build . -- install


### PR DESCRIPTION
Cirrus is deprecating x86-64 macOS support from 2023-01-01, but it seems this environment is already degraded and cannot run Pytest anymore.