### PR TITLE
only store relevant line content in the database

### DIFF
--- a/libclink/include/clink/vim.h
+++ b/libclink/include/clink/vim.h
@@ -45,6 +45,10 @@ CLINK_API int clink_vim_read(const char *filename,
  * action being done with every result is simply to insert it into a Clink
  * database.
  *
+ * Only lines for which the database contains a symbol reference will be stored.
+ * That is, it is assumed the caller has previously `clink_db_add_symbol` any
+ * symbols whose line content they wish to be added.
+ *
  * \param db Database to insert into
  * \param filename Source file to read
  * \return 0 on success or an errno on failure

--- a/libclink/src/vim_read_into.c
+++ b/libclink/src/vim_read_into.c
@@ -1,9 +1,12 @@
+#include "db.h"
 #include "debug.h"
+#include "sql.h"
 #include <assert.h>
 #include <clink/db.h>
 #include <clink/vim.h>
 #include <ctype.h>
 #include <errno.h>
+#include <sqlite3.h>
 #include <stddef.h>
 #include <string.h>
 
@@ -11,6 +14,12 @@ typedef struct {
   clink_db_t *db;
   const char *filename;
   unsigned long lineno;
+
+  /// query for relevant line numbers of the file
+  sqlite3_stmt *stmt;
+
+  /// next relevant line number
+  unsigned long next;
 } state_t;
 
 static int insert(void *state, char *line) {
@@ -18,6 +27,27 @@ static int insert(void *state, char *line) {
   assert(line != NULL);
 
   state_t *s = state;
+  ++s->lineno;
+
+  // find the next relevant line number if necessary
+  if (s->stmt != NULL) {
+    if (s->next == 0 || s->next < s->lineno) {
+      int rc = sqlite3_step(s->stmt);
+      if (rc == SQLITE_DONE) {
+        sqlite3_finalize(s->stmt);
+        s->stmt = NULL;
+      } else if (ERROR(rc != SQLITE_ROW)) {
+        return sql_err_to_errno(rc);
+      } else {
+        s->next = sqlite3_column_int64(s->stmt, 0);
+        assert(s->next >= s->lineno && "unexpected symbol line number results");
+      }
+    }
+  }
+
+  // if this line is not relevant, skip it
+  if (s->lineno != s->next)
+    return 0;
 
   // eagerly strip leading white space from the line because we know the UI
   // wants it stripped eventually
@@ -38,7 +68,6 @@ static int insert(void *state, char *line) {
     }
   }
 
-  ++s->lineno;
   return clink_db_add_line(s->db, s->filename, s->lineno, line);
 }
 
@@ -50,6 +79,22 @@ int clink_vim_read_into(clink_db_t *db, const char *filename) {
   if (ERROR(filename == NULL))
     return EINVAL;
 
+  int rc = 0;
   state_t s = {.db = db, .filename = filename};
-  return clink_vim_read(filename, insert, &s);
+
+  // create a query to lookup relevant line numbers from the target file
+  static const char QUERY[] =
+      "select distinct line from symbols where path = @filename order by line;";
+  if (ERROR((rc = sql_prepare(db->db, QUERY, &s.stmt))))
+    goto done;
+  if (ERROR((rc = sql_bind_text(s.stmt, 1, filename))))
+    goto done;
+
+  rc = clink_vim_read(filename, insert, &s);
+
+done:
+  if (s.stmt != NULL)
+    sqlite3_finalize(s.stmt);
+
+  return rc;
 }


### PR DESCRIPTION
During syntax highlighting, the content of every line of the source file was being stored in the database. However the only content that will later be referred to is that for lines that contain a relevant symbol. For example, if a file contains:

```c
  // the foo API
  //
  // Use this to do foo stuff

  int foo(void);

  int bar(void);
```

only lines 5 and 7 will ever be needed later. This commit changes the highlighting logic to skip lines like 1-4 and 6 in the above example that contain nothing relevant.

Note that highlighting now implicitly assumes symbol addition has been prior to it running. This is always the case in the current design.

On a sample benchmark (Graphviz commit 536dbfa40f9df5a7510f29f1336829451a40f1aa) this decreases database size from 104MB to 85MB.

Github: closes #134