### PR TITLE
fix: force clang parser in the test suite

### DIFF
--- a/test/cases/basic.py
+++ b/test/cases/basic.py
@@ -7,7 +7,7 @@ class Bar():
   def __init__():
     pass
 
-# RUN: clink --build-only --database {%t} --debug {%s} >/dev/null
+# RUN: clink --build-only --database={%t} --debug {%s} >/dev/null
 
 # RUN: echo 'select path, category, line, col from symbols where name = "foo" and line < 12;' | sqlite3 {%t}
 # CHECK: {%s}|0|3|5

--- a/test/cases/comment.c
+++ b/test/cases/comment.c
@@ -6,7 +6,7 @@
    bar in a multiline comment
  */
 
-// RUN: clink --build-only --database={%t}1 --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t}1 --debug --parse-c=clang {%s} >/dev/null
 
 // RUN: echo 'select * from symbols where name = "foo";' | sqlite3 {%t}1
 // RUN: echo "marker1"

--- a/test/cases/comment.py
+++ b/test/cases/comment.py
@@ -2,7 +2,7 @@
 
 # foo in a comment
 
-# RUN: clink --build-only --database={%t} --debug {%s} >/dev/null
+# RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 # RUN: echo 'select * from symbols where name = "foo";' | sqlite3 {%t}
 # RUN: echo "marker"
 # CHECK: marker

--- a/test/cases/cr.c
+++ b/test/cases/cr.c
@@ -4,7 +4,7 @@
 
 #define baz quxint quz;
 
-// RUN: clink --build-only --database={%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 
 // RUN: echo 'select * from symbols where name = "FOO";' | sqlite3 {%t}
 // CHECK: FOO|{%s}|0|3|9|

--- a/test/cases/define-branch-0.c
+++ b/test/cases/define-branch-0.c
@@ -7,6 +7,6 @@
 #endif
 
 // XFAIL: version.parse(os.environ["LLVM_VERSION"]) < version.parse("10.0.0")
-// RUN: clink --build-only --database {%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols where name = "FOO";' | sqlite3 {%t}
 // CHECK: FOO|{%s}|0|5|9|

--- a/test/cases/define-branch-1.c
+++ b/test/cases/define-branch-1.c
@@ -5,6 +5,6 @@
 #else
 #endif
 
-// RUN: clink --build-only --database {%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols where name = "FOO";' | sqlite3 {%t}
 // CHECK: FOO|{%s}|0|4|9|

--- a/test/cases/define-branch-elif-0.c
+++ b/test/cases/define-branch-elif-0.c
@@ -7,6 +7,6 @@
 #endif
 
 // XFAIL: version.parse(os.environ["LLVM_VERSION"]) < version.parse("10.0.0")
-// RUN: clink --build-only --database {%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols where name = "FOO";' | sqlite3 {%t}
 // CHECK: FOO|{%s}|0|6|9|

--- a/test/cases/define-branch-elif-1.c
+++ b/test/cases/define-branch-elif-1.c
@@ -5,6 +5,6 @@
 #define FOO
 #endif
 
-// RUN: clink --build-only --database {%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols where name = "FOO";' | sqlite3 {%t}
 // CHECK: FOO|{%s}|0|5|9|

--- a/test/cases/define-branch-else-0.c
+++ b/test/cases/define-branch-else-0.c
@@ -5,6 +5,6 @@
 #define FOO
 #endif
 
-// RUN: clink --build-only --database {%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols where name = "FOO";' | sqlite3 {%t}
 // CHECK: FOO|{%s}|0|5|9|

--- a/test/cases/define-branch-else-1.c
+++ b/test/cases/define-branch-else-1.c
@@ -7,6 +7,6 @@
 #endif
 
 // XFAIL: version.parse(os.environ["LLVM_VERSION"]) < version.parse("10.0.0")
-// RUN: clink --build-only --database {%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols where name = "FOO";' | sqlite3 {%t}
 // CHECK: FOO|{%s}|0|6|9|

--- a/test/cases/definition-multiplication.c
+++ b/test/cases/definition-multiplication.c
@@ -10,6 +10,6 @@ void foo(void) {
   g(x * y);
 }
 
-// RUN: clink --build-only --database {%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols where name = "y" and line = 10;' | sqlite3 {%t}
 // CHECK: y|{%s}|2|10|9|foo

--- a/test/cases/definition-not-parent.c
+++ b/test/cases/definition-not-parent.c
@@ -7,6 +7,6 @@ void bar(void) {
   int r = foo();
 }
 
-// RUN: clink --build-only --database {%t} {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select parent from symbols where name = "foo" and category = 1;' | sqlite3 {%t}
 // CHECK: bar

--- a/test/cases/definition-rhs.c
+++ b/test/cases/definition-rhs.c
@@ -6,6 +6,6 @@ void foo(void) {
   int x = y * z;
 }
 
-// RUN: clink --build-only --database {%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select category from symbols where name = "z" and line = 6;' | sqlite3 {%t}
 // CHECK: 2

--- a/test/cases/empty.c
+++ b/test/cases/empty.c
@@ -1,4 +1,4 @@
 /// this is not a case itself, but instructions on how to run against a file in
 /// support/
 
-// RUN: clink --build-only --database={%t} --debug {%S}/support/empty.c
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%S}/support/empty.c

--- a/test/cases/functions-in-scopes.c
+++ b/test/cases/functions-in-scopes.c
@@ -16,7 +16,7 @@ void foo(void) {
   }
 }
 
-// RUN: clink --build-only --database {%t} {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols where category = 1 order by name;' | sqlite3 {%t}
 // CHECK: f|{%s}|1|11|7|foo
 // CHECK: g|{%s}|1|12|5|foo

--- a/test/cases/global.c
+++ b/test/cases/global.c
@@ -1,5 +1,5 @@
 int x;
 
-// RUN: clink --build-only --database {%t} {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols;' | sqlite3 {%t}
 // CHECK: x|{%s}|0|1|5|

--- a/test/cases/global_const.c
+++ b/test/cases/global_const.c
@@ -1,5 +1,5 @@
 const int x;
 
-// RUN: clink --build-only --database {%t} {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols;' | sqlite3 {%t}
 // CHECK: x|{%s}|0|1|11|

--- a/test/cases/global_const2.c
+++ b/test/cases/global_const2.c
@@ -1,5 +1,5 @@
 int const x;
 
-// RUN: clink --build-only --database {%t} {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols;' | sqlite3 {%t}
 // CHECK: x|{%s}|0|1|11|

--- a/test/cases/ifdef-no-arg.c
+++ b/test/cases/ifdef-no-arg.c
@@ -1,6 +1,6 @@
 /// check we do not read out of bounds if a preprocessor directive runs right up
 /// against the end of the file
 
-// RUN: clink --build-only --database={%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 
 #ifdef

--- a/test/cases/ifdef.c
+++ b/test/cases/ifdef.c
@@ -8,7 +8,7 @@
 #elif QUUZ
 #endif
 
-// RUN: clink --build-only --database {%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 
 // can we recognise a reference in an ifdef?
 // RUN: echo 'select * from symbols where name = "FOO";' | sqlite3 {%t}

--- a/test/cases/include.c
+++ b/test/cases/include.c
@@ -2,6 +2,6 @@
 
 #include "foo.h"
 
-// RUN: clink --build-only --database {%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols;' | sqlite3 {%t}
 // CHECK: foo.h|{%s}|3|3|1|

--- a/test/cases/include2.c
+++ b/test/cases/include2.c
@@ -2,6 +2,6 @@
 
 #include <foo.h>
 
-// RUN: clink --build-only --database {%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols;' | sqlite3 {%t}
 // CHECK: foo.h|{%s}|3|3|1|

--- a/test/cases/ltrim.c
+++ b/test/cases/ltrim.c
@@ -5,7 +5,7 @@ void foo(void) {
 }
 
 // parse this into a database with full content extraction
-// RUN: clink --build-only --database {%t} --debug --syntax-highlight=eager {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang --syntax-highlight=eager {%s} >/dev/null
 
 // we should have content extracted
 // RUN: echo 'select COUNT(*) from content where line = 4;' | sqlite3 {%t}

--- a/test/cases/macro-definition-parent.c
+++ b/test/cases/macro-definition-parent.c
@@ -8,7 +8,7 @@
 #define BAZ /* a comment
                some more lines */ our_ref
 
-// RUN: clink --build-only --database {%t} {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
 
 // RUN: echo 'select * from symbols where name = "ref";' | sqlite3 {%t}
 // CHECK: ref|{%s}|2|4|13|FOO

--- a/test/cases/macro-definition.c
+++ b/test/cases/macro-definition.c
@@ -4,7 +4,7 @@
 #define BAR something
 #define BAZ(x) something_else(x)
 
-// RUN: clink --build-only --database {%t} {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols where category = 0 order by name;' | sqlite3 {%t}
 // CHECK: BAR|{%s}|0|4|9|
 // CHECK: BAZ|{%s}|0|5|9|

--- a/test/cases/macro-parent.c
+++ b/test/cases/macro-parent.c
@@ -9,6 +9,6 @@ int foo() {
   return 0;
 }
 
-// RUN: clink --build-only --database {%t} {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols where name = "macro_call" and category = 1;' | sqlite3 {%t}
 // CHECK: macro_call|{%s}|1|8|3|foo

--- a/test/cases/repl-no-parent.c
+++ b/test/cases/repl-no-parent.c
@@ -5,7 +5,7 @@
 void foo() {
 }
 
-// RUN: clink --build-only --database={%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 // RUN: echo '0foo' | clink-repl -dl -f {%t}
 // CHECK: >> cscope: 1 lines
 // CHECK: {%s} foo 5 void foo() {{

--- a/test/cases/rerun.c
+++ b/test/cases/rerun.c
@@ -4,10 +4,10 @@ void foo(void) {
   int x = 42;
 }
 
-// RUN: clink --build-only --database={%t} --debug {%s} >/dev/null
-// RUN: clink --build-only --colour=never --database={%t} --debug --jobs=1 {%s} 2>&1 | grep --colour=never "skipping unmodified file {%s}"
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
+// RUN: clink --build-only --colour=never --database={%t} --debug --jobs=1 --parse-c=clang {%s} 2>&1 | grep --colour=never "skipping unmodified file {%s}"
 // CHECK: 0: skipping unmodified file {%s}
 
 // doing this a third time should also hit the cache
-// RUN: clink --build-only --colour=never --database={%t} --debug --jobs=1 {%s} 2>&1 | grep --colour=never "skipping unmodified file {%s}"
+// RUN: clink --build-only --colour=never --database={%t} --debug --jobs=1 --parse-c=clang {%s} 2>&1 | grep --colour=never "skipping unmodified file {%s}"
 // CHECK: 0: skipping unmodified file {%s}

--- a/test/cases/string.c
+++ b/test/cases/string.c
@@ -8,7 +8,7 @@ void fn() {
   char a = 'b';
 }
 
-// RUN: clink --build-only --database={%t}1 --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t}1 --debug --parse-c=clang {%s} >/dev/null
 
 // RUN: echo 'select name, line, col from symbols where name = "foo";' | sqlite3 {%t}1
 // CHECK: foo|4|15

--- a/test/cases/trailing-line.c
+++ b/test/cases/trailing-line.c
@@ -1,6 +1,6 @@
 /// a trailing blank line should not result in a read out of bounds
 
-// RUN: clink --build-only --database={%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 
 int x;
 

--- a/test/cases/undef.c
+++ b/test/cases/undef.c
@@ -2,6 +2,6 @@
 
 #undef FOO
 
-// RUN: clink --build-only --database {%t} --debug {%s} >/dev/null
+// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 // RUN: echo 'select * from symbols;' | sqlite3 {%t}
 // CHECK: FOO|{%s}|2|3|8|


### PR DESCRIPTION
The change in 3fec779f6a9a18daa3a2661abc204704fe29ab8b made these tests default to Cscope when it was installed. This continued passing in CI where Cscope is not installed but would fail locally. These tests are supposed to probe the Clang-based parser. We care less about the Cscope-based one whose behaviour is known and not changeable.