### PR TITLE
join: open code 'asprintf' call

### DIFF
--- a/clink/src/join.c
+++ b/clink/src/join.c
@@ -1,7 +1,8 @@
+#include "../../common/compiler.h"
 #include "path.h"
 #include <errno.h>
-#include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 int join(const char *branch, const char *stem, char **path) {
@@ -31,8 +32,16 @@ int join(const char *branch, const char *stem, char **path) {
   while (*suffix == '/')
     ++suffix;
 
-  if (asprintf(path, "%.*s/%s", (int)prefix_len, branch, suffix) < 0)
+  // construct the joined path
+  size_t suffix_len = strlen(suffix);
+  char *p = malloc(prefix_len + 1 + suffix_len + 1);
+  if (UNLIKELY(p == NULL))
     return ENOMEM;
+  memcpy(p, branch, prefix_len);
+  p[prefix_len] = '/';
+  memcpy(&p[prefix_len + 1], suffix, suffix_len + 1);
+
+  *path = p;
 
   return 0;
 }


### PR DESCRIPTION
Surprisingly `asprintf` shows up in profiling as 4.78% of the cost of a no-op re-build and 0-result returning search. Reading the GCC docs, the compiler does not know this function as a built-in. Moving to an `sprintf`/`snprintf` version has no effect; apparently GCC’s knowledge of these functions as built-ins does not help either. However going all the way to breaking the string construction into its basic elements does have an impact. This drops `asprintf` below 1% in this particular scenario. Overall execution time is sped up by ~3.86%.