### PR TITLE
disallow \r and \n in comment delimiters

### DIFF
--- a/libclink/include/clink/generic.h
+++ b/libclink/include/clink/generic.h
@@ -38,6 +38,9 @@ typedef struct {
  * (`CLINK_DEFINITION`) and references (`CLINK_REFERENCE`), and even these are
  * just educated guesses.
  *
+ * The comment start and end markers defined in \p lang->comments cannot include
+ * newline characters ('\n' and '\r').
+ *
  * \param db Database to insert into
  * \param filename Path to source file to parse
  * \param lang The source language for interpreting this file

--- a/libclink/src/parse_generic.c
+++ b/libclink/src/parse_generic.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <string.h>
 
 static int parse(clink_db_t *db, const char *filename, const clink_lang_t *lang,
                  scanner_t s) {
@@ -126,6 +127,22 @@ int clink_parse_generic(clink_db_t *db, const char *filename,
 
   if (ERROR(lang == NULL))
     return EINVAL;
+
+  // disallow newline characters in comment delimiters
+  if (lang->comments != NULL) {
+    for (size_t i = 0; lang->comments[i].start != NULL; ++i) {
+      if (ERROR(strchr(lang->comments[i].start, '\r') != NULL))
+        return EINVAL;
+      if (ERROR(strchr(lang->comments[i].start, '\n') != NULL))
+        return EINVAL;
+      if (lang->comments[i].end != NULL) {
+        if (ERROR(strchr(lang->comments[i].end, '\r') != NULL))
+          return EINVAL;
+        if (ERROR(strchr(lang->comments[i].end, '\n') != NULL))
+          return EINVAL;
+      }
+    }
+  }
 
   int rc = 0;
   mmap_t mapped = {0};

--- a/libclink/src/scanner.c
+++ b/libclink/src/scanner.c
@@ -76,9 +76,8 @@ bool eat_if(scanner_t *s, const char *expected) {
 
 #ifndef NDEBUG
   for (size_t i = 0; i < strlen(expected); ++i) {
-    if (expected[i] == '\r')
-      assert(i + 1 != strlen(expected) && expected[i + 1] == '\n' &&
-             "orphaned CR in expected text");
+    assert(expected[i] != '\r');
+    assert(expected[i] != '\n');
   }
 #endif
 
@@ -89,19 +88,7 @@ bool eat_if(scanner_t *s, const char *expected) {
     return false;
 
   s->offset += strlen(expected);
-
-  for (size_t i = 0; i < strlen(expected); ++i) {
-    if (strncmp(&expected[i], "\r\n", strlen("\r\n")) == 0) {
-      ++i;
-      ++s->lineno;
-      s->colno = 1;
-    } else if (expected[i] == '\n') {
-      ++s->lineno;
-      s->colno = 1;
-    } else {
-      ++s->colno;
-    }
-  }
+  s->colno += strlen(expected);
 
   return true;
 }


### PR DESCRIPTION
When using Cscope-based parsing, `eat_if` shows up as 2.90% of execution time, not including its callers. By banning newline characters from comment starters and enders, we can omit the trailer of `eat_if`. This is a reduction of 4.16% in instructions executed and 1.72% in execution time.

It is surprising that `eat_if` seems to get neither inlined or specialised despite looking like a perfect candidate for this.