### PR TITLE
fix space advancing too far in results view

### DIFF
--- a/clink/src/ui.c
+++ b/clink/src/ui.c
@@ -941,8 +941,11 @@ static int handle_select(void) {
   }
 
   if (e.type == EVENT_KEYPRESS && e.value == ' ') {
-    if (from_row + usable_rows() < results.count) {
-      from_row += usable_rows();
+    size_t increment = usable_rows();
+    if (increment > sizeof(HOTKEYS) - 1)
+      increment = sizeof(HOTKEYS) - 1;
+    if (from_row + increment < results.count) {
+      from_row += increment;
     } else {
       from_row = 0;
     }


### PR DESCRIPTION
When hitting space, the UI logic would mistakenly assume the entire usable rows were being used. This was not true when the terminal size was large enough to have more usable rows than the number of hot keys. The result of this would be skipping some results as you advanced between pages.