### PR TITLE
standardise on GCC atomic built-ins

### DIFF
--- a/libclink/src/db.h
+++ b/libclink/src/db.h
@@ -2,7 +2,6 @@
 
 #include "re.h"
 #include <sqlite3.h>
-#include <stdatomic.h>
 
 struct clink_db {
 
@@ -13,5 +12,5 @@ struct clink_db {
   sqlite3 *db;
 
   /// pre-compiled regexes
-  re_t *_Atomic regexes;
+  re_t *regexes;
 };

--- a/libclink/src/re.h
+++ b/libclink/src/re.h
@@ -3,7 +3,6 @@
 #include "../../common/compiler.h"
 #include <regex.h>
 #include <sqlite3.h>
-#include <stdatomic.h>
 
 /// translate a POSIX regex.h error to an errno
 INTERNAL int re_err_to_errno(int err);
@@ -28,7 +27,7 @@ typedef struct re {
  * \param regex Regex to compile
  * \return 0 on success or an errno on failure
  */
-INTERNAL int re_add(re_t *_Atomic *re, const char *regex);
+INTERNAL int re_add(re_t **re, const char *regex);
 
 /** lookup a previously compiled regex
  *
@@ -42,7 +41,7 @@ INTERNAL int re_add(re_t *_Atomic *re, const char *regex);
  * \param regex Originating regex text
  * \return The matching previously compiled regex
  */
-INTERNAL regex_t re_find(const re_t *_Atomic *re, const char *regex);
+INTERNAL regex_t re_find(const re_t **re, const char *regex);
 
 /** cleanup pre-compiled regexes
  *

--- a/libclink/src/re_add.c
+++ b/libclink/src/re_add.c
@@ -3,11 +3,10 @@
 #include <assert.h>
 #include <errno.h>
 #include <regex.h>
-#include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
 
-int re_add(re_t *_Atomic *re, const char *regex) {
+int re_add(re_t **re, const char *regex) {
   assert(re != NULL);
   assert(regex != NULL);
 
@@ -35,11 +34,11 @@ int re_add(re_t *_Atomic *re, const char *regex) {
   }
 
   {
-    re_t *head = atomic_load_explicit(re, memory_order_acquire);
+    re_t *head = __atomic_load_n(re, __ATOMIC_ACQUIRE);
     do {
       r->next = head;
-    } while (!atomic_compare_exchange_weak_explicit(
-        re, &head, r, memory_order_release, memory_order_acquire));
+    } while (!__atomic_compare_exchange_n(re, &head, r, true, __ATOMIC_RELEASE,
+                                          __ATOMIC_ACQUIRE));
   }
 
 done:

--- a/libclink/src/re_find.c
+++ b/libclink/src/re_find.c
@@ -2,15 +2,14 @@
 #include "re.h"
 #include <assert.h>
 #include <regex.h>
-#include <stdatomic.h>
 #include <stddef.h>
 #include <string.h>
 
-regex_t re_find(const re_t *_Atomic *re, const char *regex) {
+regex_t re_find(const re_t **re, const char *regex) {
   assert(re != NULL);
   assert(regex != NULL);
 
-  const re_t *r = atomic_load_explicit(re, memory_order_acquire);
+  const re_t *r = __atomic_load_n(re, __ATOMIC_ACQUIRE);
   while (r != NULL) {
     if (strcmp(r->expression, regex) == 0)
       return r->compiled;

--- a/libclink/src/re_sqlite.c
+++ b/libclink/src/re_sqlite.c
@@ -3,7 +3,6 @@
 #include <assert.h>
 #include <regex.h>
 #include <sqlite3.h>
-#include <stdatomic.h>
 #include <stddef.h>
 
 void re_sqlite(sqlite3_context *context, int argc, sqlite3_value **argv) {
@@ -20,7 +19,7 @@ void re_sqlite(sqlite3_context *context, int argc, sqlite3_value **argv) {
   assert(text != NULL);
 
   // retrieve the pre-compiled regex state that was setup by `db_open`
-  const re_t *_Atomic *re = sqlite3_user_data(context);
+  const re_t **re = sqlite3_user_data(context);
   assert(re != NULL);
 
   // find our matching regex which should have been pre-compiled


### PR DESCRIPTION
The code was using a mixture of GCC atomic built-ins and C11 atomics. Since we had to use the former anyway (to get per-site selection of atomic/non-atomic access), there did not seem to be any point to mixing its use with the latter.