### PR TITLE
fix: shell-escape commands being passed to Bash in the test suite

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,7 +7,7 @@ task:
 
     - name: FreeBSD
       freebsd_instance:
-        image_family: freebsd-14-0-snap
+        image_family: freebsd-13-1
       environment:
         CFLAGS: -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=undefined
         UBSAN_OPTIONS: print_stacktrace=1

--- a/misc/ci.sh
+++ b/misc/ci.sh
@@ -4,6 +4,9 @@ set -e
 set -x
 
 uname -sr
+which bash
+which python3
+python3 --version
 
 git submodule init
 git submodule update


### PR DESCRIPTION
This seems to have begun causing problems on FreeBSD in CI:

  def run(*popenargs,
  …
    retcode = process.poll()
    if check and retcode:
  >   raise CalledProcessError(retcode, process.args,
  E               subprocess.CalledProcessError: Command '['bash', '-o',
    'pipefail', '-c', '--', 'echo \'select name, line, col from symbols where
    name = "foo";\' | sqlite3
    /tmp/pytest-of-root/pytest-0/test_case_string_c_0/tempfile1']' returned
    non-zero exit status 1.
  /usr/local/lib/python3.9/subprocess.py:528: CalledProcessError
  ----------------------------- Captured stderr call -----------------------------
  [CLINK] clink/src/option.c:231: failed to open /tmp/pytest-of-root/pytest-0/test_case_string_c_0/compile_commands.json
  [CLINK] clink/src/option.c:244: failed to open /tmp/pytest-of-root/pytest-0/test_case_string_c_0/build/compile_commands.json
  setting up compile commands failed: No message of desired type
  [CLINK] libclink/src/parse_with_clang.c:546: processed symbol fn, rc = 0
  [CLINK] libclink/src/parse_with_clang.c:198: setting parent fn for recursion
  [CLINK] libclink/src/parse_with_clang.c:404: recursing past irrelevant cursor 202
  [CLINK] libclink/src/parse_with_clang.c:404: recursing past irrelevant cursor 231
  [CLINK] libclink/src/parse_with_clang.c:546: processed symbol foo, rc = 0
  [CLINK] libclink/src/parse_with_clang.c:546: processed symbol , rc = 0
  [CLINK] libclink/src/parse_with_clang.c:546: processed symbol , rc = 0
  [CLINK] libclink/src/parse_with_clang.c:404: recursing past irrelevant cursor 109
  [CLINK] libclink/src/parse_with_clang.c:404: recursing past irrelevant cursor 231
  [CLINK] libclink/src/parse_with_clang.c:546: processed symbol baz, rc = 0
  [CLINK] libclink/src/parse_with_clang.c:546: processed symbol , rc = 0
  [CLINK] libclink/src/parse_with_clang.c:546: processed symbol , rc = 0
  [CLINK] libclink/src/parse_with_clang.c:404: recursing past irrelevant cursor 109
  [CLINK] libclink/src/parse_with_clang.c:404: recursing past irrelevant cursor 231
  [CLINK] libclink/src/parse_with_clang.c:546: processed symbol a, rc = 0
  [CLINK] libclink/src/parse_with_clang.c:546: processed symbol , rc = 0
  [CLINK] libclink/src/parse_with_clang.c:404: recursing past irrelevant cursor 110
  Parse error near line 1: no such column: foo
    select name, line, col from symbols where name = "foo";
                                       error here ---^