### PR TITLE
normalise symbol table

### DIFF
--- a/clink/src/build.c
+++ b/clink/src/build.c
@@ -252,11 +252,11 @@ static int process(unsigned long thread_id, pthread_t *threads, clink_db_t *db,
     // remove anything related to the file we are about to parse
     clink_db_remove(db, path);
 
+    // insert a new record for the file
+    (void)clink_db_add_record(db, path, hash, timestamp, NULL);
+
     if (UNLIKELY((rc = parse(thread_id, db, path))))
       break;
-
-    // now we can insert a record for the file
-    (void)clink_db_add_record(db, path, hash, timestamp, NULL);
 
     // bump the progress counter
     progress_increment();

--- a/clink/src/build.c
+++ b/clink/src/build.c
@@ -256,7 +256,7 @@ static int process(unsigned long thread_id, pthread_t *threads, clink_db_t *db,
       break;
 
     // now we can insert a record for the file
-    (void)clink_db_add_record(db, path, hash, timestamp);
+    (void)clink_db_add_record(db, path, hash, timestamp, NULL);
 
     // bump the progress counter
     progress_increment();

--- a/clink/src/build.c
+++ b/clink/src/build.c
@@ -138,7 +138,7 @@ static int parse(unsigned long thread_id, clink_db_t *db, const char *path) {
   } else if (use_cscope(path)) {
     progress_status(thread_id, "Cscope-parsing %s file %s", filetype(path),
                     display);
-    rc = clink_parse_with_cscope(db, path);
+    rc = clink_parse_with_cscope(db, path, -1);
 
   } else if (is_asm(path)) {
 

--- a/clink/src/build.c
+++ b/clink/src/build.c
@@ -102,7 +102,10 @@ static const char *filetype(const char *path) {
   return is_c(path) ? "C" : "C++";
 }
 
-static int parse(unsigned long thread_id, clink_db_t *db, const char *path) {
+static int parse(unsigned long thread_id, clink_db_t *db, const char *path,
+                 clink_record_id_t id) {
+
+  assert(id >= 0);
 
   int rc = 0;
 
@@ -138,7 +141,7 @@ static int parse(unsigned long thread_id, clink_db_t *db, const char *path) {
   } else if (use_cscope(path)) {
     progress_status(thread_id, "Cscope-parsing %s file %s", filetype(path),
                     display);
-    rc = clink_parse_with_cscope(db, path, -1);
+    rc = clink_parse_with_cscope(db, path, id);
 
   } else if (is_asm(path)) {
 
@@ -253,9 +256,10 @@ static int process(unsigned long thread_id, pthread_t *threads, clink_db_t *db,
     clink_db_remove(db, path);
 
     // insert a new record for the file
-    (void)clink_db_add_record(db, path, hash, timestamp, NULL);
+    clink_record_id_t id = -1;
+    (void)clink_db_add_record(db, path, hash, timestamp, &id);
 
-    if (UNLIKELY((rc = parse(thread_id, db, path))))
+    if (UNLIKELY((rc = parse(thread_id, db, path, id))))
       break;
 
     // bump the progress counter

--- a/clink/src/clink-repl
+++ b/clink/src/clink-repl
@@ -86,10 +86,11 @@ def in_bw(s: Optional[str]) -> str:
 def find_symbol(db: sqlite3.Connection, name: str):
     logging.debug(f"find_symbol of {name}")
     SQL = (
-        "select symbols.path, symbols.parent, symbols.line, content.body "
-        "from symbols left join content on symbols.path = content.path and "
+        "select records.path, symbols.parent, symbols.line, content.body "
+        "from symbols inner join records on symbols.path = records.id "
+        "left join content on records.path = content.path and "
         "symbols.line = content.line where symbols.name = :name order by "
-        "symbols.path, symbols.line, symbols.col;"
+        "records.path, symbols.line, symbols.col;"
     )
     rows = select(db, SQL, {"name": name})
     print(f"cscope: {len(rows)} lines")
@@ -100,11 +101,12 @@ def find_symbol(db: sqlite3.Connection, name: str):
 def find_definition(db: sqlite3.Connection, name: str):
     logging.debug(f"find_definition of {name}")
     SQL = (
-        "select symbols.path, symbols.line, content.body "
-        "from symbols left join content on symbols.path = content.path and "
+        "select records.path, symbols.line, content.body "
+        "from symbols inner join records on symbols.path = records.id "
+        "left join content on records.path = content.path and "
         "symbols.line = content.line where symbols.name = :name and "
         f"symbols.category = {CLINK_DEFINITION} order by "
-        "symbols.path, symbols.line, symbols.col;"
+        "records.path, symbols.line, symbols.col;"
     )
     rows = select(db, SQL, {"name": name})
     print(f"cscope: {len(rows)} lines")
@@ -115,11 +117,12 @@ def find_definition(db: sqlite3.Connection, name: str):
 def find_calls(db: sqlite3.Connection, caller: str):
     logging.debug(f"find_calls of {caller}")
     SQL = (
-        "select symbols.path, symbols.name, symbols.line, content.body "
-        "from symbols left join content on symbols.path = content.path and "
+        "select records.path, symbols.name, symbols.line, content.body "
+        "from symbols inner join records on symbols.path = records.id "
+        "left join content on records.path = content.path and "
         "symbols.line = content.line where symbols.parent = :caller and "
         f"symbols.category = {CLINK_FUNCTION_CALL} order by "
-        "symbols.path, symbols.line, symbols.col;"
+        "records.path, symbols.line, symbols.col;"
     )
     rows = select(db, SQL, {"caller": caller})
     print(f"cscope: {len(rows)} lines")
@@ -130,11 +133,12 @@ def find_calls(db: sqlite3.Connection, caller: str):
 def find_callers(db: sqlite3.Connection, callee: str):
     logging.debug(f"find_callers of {callee}")
     SQL = (
-        "select symbols.path, symbols.parent, symbols.line, content.body "
-        "from symbols left join content on symbols.path = content.path and "
+        "select records.path, symbols.parent, symbols.line, content.body "
+        "from symbols inner join records on symbols.path = records.id "
+        "left join content on records.path = content.path and "
         "symbols.line = content.line where symbols.name = :callee and "
         f"symbols.category = {CLINK_FUNCTION_CALL} order by "
-        "symbols.path, symbols.line, symbols.col;"
+        "records.path, symbols.line, symbols.col;"
     )
     rows = select(db, SQL, {"callee": callee})
     print(f"cscope: {len(rows)} lines")
@@ -145,7 +149,7 @@ def find_callers(db: sqlite3.Connection, callee: str):
 def find_file(db: sqlite3.Connection, filename: str):
     logging.debug(f"find_file of {filename}")
     SQL = (
-        "select distinct path from symbols where path = :filename or "
+        "select distinct path from records where path = :filename or "
         "path like :pattern order by path"
     )
     rows = select(db, SQL, {"filename": filename, "pattern": f"%/{filename}"})
@@ -157,11 +161,12 @@ def find_file(db: sqlite3.Connection, filename: str):
 def find_includers(db: sqlite3.Connection, path: str):
     logging.debug(f"find_includers of {path}")
     SQL = (
-        "select symbols.path, symbols.parent, symbols.line, content.body "
-        "from symbols left join content on symbols.path = content.path and "
+        "select records.path, symbols.parent, symbols.line, content.body "
+        "from symbols inner join records on symbols.path = records.id "
+        "left join content on records.path = content.path and "
         "symbols.line = content.line where symbols.name like :name and "
         f"symbols.category = {CLINK_INCLUDE} order by "
-        "symbols.path, symbols.line, symbols.col;"
+        "records.path, symbols.line, symbols.col;"
     )
     rows = select(db, SQL, {"name": f"%{path}"})
     print(f"cscope: {len(rows)} lines")

--- a/libclink/CMakeLists.txt
+++ b/libclink/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(libclink
   src/eat_num.c
   src/eat_rest_of_line.c
   src/get_environ.c
+  src/get_id.c
   src/have_cscope.c
   src/iter.c
   src/mmap.c

--- a/libclink/include/clink/cscope.h
+++ b/libclink/include/clink/cscope.h
@@ -22,11 +22,17 @@ CLINK_API bool clink_have_cscope(void);
  * This function encapsulates executing \p cscope, parsing the database it
  * writes back into memory, and then writing this into a Clink database.
  *
+ * If the caller knows the identifier of the record for the source path
+ * \p filename, they can pass this as \p id. If not, they can pass -1 to
+ * indicate the callee needs to look this up.
+ *
  * \param db Database to insert into
  * \param filename Path to source file to parse
+ * \param id Identifier of the record of \p filename
  * \return 0 on success or an errno on failure
  */
-CLINK_API int clink_parse_with_cscope(clink_db_t *db, const char *filename);
+CLINK_API int clink_parse_with_cscope(clink_db_t *db, const char *filename,
+                                      clink_record_id_t id);
 
 #ifdef __cplusplus
 }

--- a/libclink/include/clink/db.h
+++ b/libclink/include/clink/db.h
@@ -49,6 +49,9 @@ CLINK_API int clink_db_begin_transaction(clink_db_t *db);
  */
 CLINK_API int clink_db_commit_transaction(clink_db_t *db);
 
+/// identifier/handle for a record
+typedef int64_t clink_record_id_t;
+
 /** add a file record to the database
  *
  * Nothing in the symbol or content functionality assumes a corresponding file
@@ -61,10 +64,12 @@ CLINK_API int clink_db_commit_transaction(clink_db_t *db);
  * \param path Path of the subject to store information about
  * \param hash Some hash digest of the subject
  * \param timestamp Last modification time of the subject
+ * \param id [out] Identifier of the inserted record on success
  * \return 0 on success or an errno on failure
  */
 CLINK_API int clink_db_add_record(clink_db_t *db, const char *path,
-                                  uint64_t hash, uint64_t timestamp);
+                                  uint64_t hash, uint64_t timestamp,
+                                  clink_record_id_t *id);
 
 /** add a symbol to the database
  *

--- a/libclink/src/add_symbol.h
+++ b/libclink/src/add_symbol.h
@@ -32,6 +32,12 @@ typedef struct {
 INTERNAL int add_symbols(clink_db_t *db, size_t syms_size, symbol_t *syms,
                          clink_record_id_t id);
 
-static inline int add_symbol(clink_db_t *db, symbol_t sym) {
-  return add_symbols(db, 1, &sym, -1);
-}
+/// convenience wrapper for \p add_symbols with a single symbol
+///
+/// There is no way to set the \p id parameter to \p add_symbols when calling
+/// through this interface.
+///
+/// \param db Database to operate on
+/// \param sym Symbol to insert
+/// \return 0 on success or an errno on failure
+INTERNAL int add_symbol(clink_db_t *db, symbol_t sym);

--- a/libclink/src/add_symbol.h
+++ b/libclink/src/add_symbol.h
@@ -19,12 +19,19 @@ typedef struct {
 /// This function provides a way of inserting multiple symbols into the database
 /// in a single operation.
 ///
+/// If all symbols being inserted are from the same source path and the caller
+/// knows the record identifier of this path, they can pass it as \p id as an
+/// optimisation. If not, they can pass -1 as a default.
+///
 /// \param db Database to operate on
 /// \param syms_size Number of elements in \p syms
 /// \param syms Symbols to insert
+/// \param id Identifier of the record for the source path containing all
+///   symbols
 /// \return 0 on success or an errno on failure
-INTERNAL int add_symbols(clink_db_t *db, size_t syms_size, symbol_t *syms);
+INTERNAL int add_symbols(clink_db_t *db, size_t syms_size, symbol_t *syms,
+                         clink_record_id_t id);
 
 static inline int add_symbol(clink_db_t *db, symbol_t sym) {
-  return add_symbols(db, 1, &sym);
+  return add_symbols(db, 1, &sym, -1);
 }

--- a/libclink/src/add_symbol.h
+++ b/libclink/src/add_symbol.h
@@ -19,9 +19,8 @@ typedef struct {
 /// This function provides a way of inserting multiple symbols into the database
 /// in a single operation.
 ///
-/// If all symbols being inserted are from the same source path and the caller
-/// knows the record identifier of this path, they can pass it as \p id as an
-/// optimisation. If not, they can pass -1 as a default.
+/// All symbols being inserted must be from the same source path. The caller
+/// must supply the record identifier of this path as \p id.
 ///
 /// \param db Database to operate on
 /// \param syms_size Number of elements in \p syms

--- a/libclink/src/add_symbol.h
+++ b/libclink/src/add_symbol.h
@@ -14,7 +14,7 @@ typedef struct {
   span_t parent;             ///< optional containing definition
 } symbol_t;
 
-/// a version of \p clink_db_add_symbol` with a different calling convention
+/// a version of \p clink_db_add_symbol with a different calling convention
 ///
 /// This function provides a way of inserting multiple symbols into the database
 /// in a single operation.

--- a/libclink/src/db_add_symbol.c
+++ b/libclink/src/db_add_symbol.c
@@ -61,6 +61,7 @@ int add_symbols(clink_db_t *db, size_t syms_size, symbol_t *syms,
 
   assert(db != NULL);
   assert(syms_size == 0 || syms != NULL);
+  assert(id >= 0);
 
   // insert into the symbol table
 
@@ -88,29 +89,19 @@ int add_symbols(clink_db_t *db, size_t syms_size, symbol_t *syms,
       assert(r == SQLITE_OK);
     }
 
-    clink_record_id_t this_id = -1;
-    // did the caller give us a common identifier?
-    if (id >= 0) {
 #ifndef NDEBUG
-      // if the caller passed both `path` and `id`, do them a favour and
-      // validate these match
-      if (syms[i].path != NULL) {
-        clink_record_id_t cross_reference = -1;
-        if (ERROR((rc = get_id(db, syms[i].path, &cross_reference))))
-          goto done;
-        assert(cross_reference == id);
-      }
-#endif
-      this_id = id;
-    } else {
-      // find the identifier for this symbol’s path
-      assert(syms[i].path != NULL);
-      if (ERROR((rc = get_id(db, syms[i].path, &this_id))))
+    // if the caller passed a `path`, do them a favour and validate this matches
+    // `id`
+    if (syms[i].path != NULL) {
+      clink_record_id_t cross_reference = -1;
+      if (ERROR((rc = get_id(db, syms[i].path, &cross_reference))))
         goto done;
+      assert(cross_reference == id);
     }
+#endif
 
-    if (ERROR((rc = add(s, syms[i].category, syms[i].name, this_id,
-                        syms[i].parent))))
+    if (ERROR(
+            (rc = add(s, syms[i].category, syms[i].name, id, syms[i].parent))))
       goto done;
   }
 

--- a/libclink/src/db_add_symbol.c
+++ b/libclink/src/db_add_symbol.c
@@ -126,6 +126,10 @@ done:
   return rc;
 }
 
+int add_symbol(clink_db_t *db, symbol_t sym) {
+  return add_symbols(db, 1, &sym, -1);
+}
+
 int clink_db_add_symbol(clink_db_t *db, const clink_symbol_t *symbol) {
 
   if (ERROR(db == NULL))

--- a/libclink/src/db_add_symbol.c
+++ b/libclink/src/db_add_symbol.c
@@ -127,7 +127,21 @@ done:
 }
 
 int add_symbol(clink_db_t *db, symbol_t sym) {
-  return add_symbols(db, 1, &sym, -1);
+
+  assert(db != NULL);
+
+  int rc = 0;
+
+  // find the identifier for this symbol’s path
+  clink_record_id_t id = -1;
+  assert(sym.path != NULL);
+  if (ERROR((rc = get_id(db, sym.path, &id))))
+    goto done;
+
+  rc = add_symbols(db, 1, &sym, id);
+
+done:
+  return rc;
 }
 
 int clink_db_add_symbol(clink_db_t *db, const clink_symbol_t *symbol) {

--- a/libclink/src/db_find_call.c
+++ b/libclink/src/db_find_call.c
@@ -111,12 +111,13 @@ int clink_db_find_call(clink_db_t *db, const char *regex, clink_iter_t **it) {
     return EINVAL;
 
   static const char QUERY[] =
-      "select symbols.name, symbols.path, symbols.line, symbols.col, "
-      "symbols.parent, content.body from symbols left join content "
+      "select symbols.name, records.path, symbols.line, symbols.col, "
+      "symbols.parent, content.body from symbols inner join records "
+      "on symbols.path = records.id left join content "
       "on "
-      "symbols.path = content.path and symbols.line = content.line where "
+      "records.path = content.path and symbols.line = content.line where "
       "symbols.parent regexp @parent and symbols.category = @category order by "
-      "symbols.path, symbols.line, symbols.col;";
+      "records.path, symbols.line, symbols.col;";
 
   int rc = 0;
   clink_iter_t *i = NULL;

--- a/libclink/src/db_find_caller.c
+++ b/libclink/src/db_find_caller.c
@@ -110,11 +110,12 @@ int clink_db_find_caller(clink_db_t *db, const char *regex, clink_iter_t **it) {
     return EINVAL;
 
   static const char QUERY[] =
-      "select symbols.name, symbols.path, symbols.line, symbols.col, "
-      "symbols.parent, content.body from symbols left join content on "
-      "symbols.path = content.path and symbols.line = content.line where "
+      "select symbols.name, records.path, symbols.line, symbols.col, "
+      "symbols.parent, content.body from symbols inner join records "
+      "on symbols.path = records.id left join content on "
+      "records.path = content.path and symbols.line = content.line where "
       "symbols.name regexp @name and symbols.category = @category order by "
-      "symbols.path, symbols.line, symbols.col;";
+      "records.path, symbols.line, symbols.col;";
 
   int rc = 0;
   clink_iter_t *i = NULL;

--- a/libclink/src/db_find_definition.c
+++ b/libclink/src/db_find_definition.c
@@ -111,11 +111,12 @@ int clink_db_find_definition(clink_db_t *db, const char *regex,
     return EINVAL;
 
   static const char QUERY[] =
-      "select symbols.name, symbols.path, symbols.line, symbols.col, "
-      "symbols.parent, content.body from symbols left join content on "
-      "symbols.path = content.path and symbols.line = content.line where "
+      "select symbols.name, records.path, symbols.line, symbols.col, "
+      "symbols.parent, content.body from symbols inner join records "
+      "on symbols.path = records.id left join content on "
+      "records.path = content.path and symbols.line = content.line where "
       "symbols.name regexp @name and symbols.category = @category order by "
-      "symbols.path, symbols.line, symbols.col;";
+      "records.path, symbols.line, symbols.col;";
 
   int rc = 0;
   clink_iter_t *i = NULL;

--- a/libclink/src/db_find_includer.c
+++ b/libclink/src/db_find_includer.c
@@ -111,12 +111,13 @@ int clink_db_find_includer(clink_db_t *db, const char *regex,
     return EINVAL;
 
   static const char QUERY[] =
-      "select symbols.name, symbols.path, symbols.line,"
-      "symbols.col, symbols.parent, content.body from symbols left join "
+      "select symbols.name, records.path, symbols.line,"
+      "symbols.col, symbols.parent, content.body from symbols inner join "
+      "records on symbols.path = records.id left join "
       "content "
-      "on symbols.path = content.path and symbols.line = content.line where "
+      "on records.path = content.path and symbols.line = content.line where "
       "symbols.name regexp @name and symbols.category = @category order "
-      "by symbols.path, symbols.line, symbols.col;";
+      "by records.path, symbols.line, symbols.col;";
 
   int rc = 0;
   clink_iter_t *i = NULL;

--- a/libclink/src/db_find_symbol.c
+++ b/libclink/src/db_find_symbol.c
@@ -110,11 +110,12 @@ int clink_db_find_symbol(clink_db_t *db, const char *regex, clink_iter_t **it) {
     return EINVAL;
 
   static const char QUERY[] =
-      "select symbols.name, symbols.path, symbols.category, "
+      "select symbols.name, records.path, symbols.category, "
       "symbols.line, symbols.col, symbols.parent, content.body from symbols "
+      "inner join records on symbols.path = records.id "
       "left "
-      "join content on symbols.path = content.path and symbols.line = "
-      "content.line where symbols.name regexp @name order by symbols.path, "
+      "join content on records.path = content.path and symbols.line = "
+      "content.line where symbols.name regexp @name order by records.path, "
       "symbols.line, symbols.col;";
 
   int rc = 0;

--- a/libclink/src/db_open.c
+++ b/libclink/src/db_open.c
@@ -42,6 +42,7 @@ static int configure(sqlite3 *db) {
       "pragma synchronous=OFF;",
       "pragma journal_mode=OFF;",
       "pragma temp_store=MEMORY;",
+      "pragma foreign_keys=ON;",
   };
 
   return exec_all(db, sizeof(PRAGMAS) / sizeof(PRAGMAS[0]), PRAGMAS);

--- a/libclink/src/db_remove.c
+++ b/libclink/src/db_remove.c
@@ -1,5 +1,6 @@
 #include "db.h"
 #include "debug.h"
+#include "get_id.h"
 #include "sql.h"
 #include <clink/db.h>
 #include <sqlite3.h>
@@ -16,7 +17,20 @@ void clink_db_remove(clink_db_t *db, const char *path) {
   if (ERROR(path == NULL))
     return;
 
-  // first delete it from the symbols table
+  // find the record identifier for this path
+  clink_record_id_t id = -1;
+  {
+    int r = get_id(db, path, &id);
+    if (r == ENOENT) {
+      // this path already does not exist in the database
+      return;
+    }
+    // if something else went wrong, give up
+    if (ERROR(r != 0))
+      return;
+  }
+
+  // delete the path from the symbols table
   {
     static const char SYMBOLS_DELETE[] =
         "delete from symbols where path = @path";
@@ -25,7 +39,7 @@ void clink_db_remove(clink_db_t *db, const char *path) {
     if (ERROR(sql_prepare(db->db, SYMBOLS_DELETE, &s)))
       return;
 
-    if (ERROR(sql_bind_text(s, 1, path))) {
+    if (ERROR(sql_bind_int(s, 1, id))) {
       sqlite3_finalize(s);
       return;
     }

--- a/libclink/src/get_id.c
+++ b/libclink/src/get_id.c
@@ -1,0 +1,47 @@
+#include "get_id.h"
+#include "db.h"
+#include "debug.h"
+#include "sql.h"
+#include <assert.h>
+#include <clink/db.h>
+#include <errno.h>
+#include <sqlite3.h>
+#include <stddef.h>
+
+int get_id(clink_db_t *db, const char *path, clink_record_id_t *id) {
+
+  assert(db != NULL);
+  assert(path != NULL);
+  assert(id != NULL);
+
+  int rc = 0;
+
+  static const char LOOKUP[] = "select id from records where path = @path;";
+
+  sqlite3_stmt *lookup = NULL;
+  if (ERROR((rc = sql_prepare(db->db, LOOKUP, &lookup))))
+    goto done;
+
+  if (ERROR((rc = sql_bind_text(lookup, 1, path))))
+    goto done;
+
+  {
+    int r = sqlite3_step(lookup);
+    if (ERROR(r != SQLITE_ROW)) {
+      if (r == SQLITE_DONE) {
+        rc = ENOENT;
+      } else {
+        rc = sql_err_to_errno(r);
+      }
+      goto done;
+    }
+  }
+
+  *id = sqlite3_column_int64(lookup, 0);
+
+done:
+  if (lookup != NULL)
+    sqlite3_finalize(lookup);
+
+  return rc;
+}

--- a/libclink/src/get_id.h
+++ b/libclink/src/get_id.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../../common/compiler.h"
+#include <clink/db.h>
+
+/// find the record identifier for the given path
+///
+/// This function returns \p ENOENT if \p path does not exist in the
+/// database’s record table.
+///
+/// \param db Database to operate on
+/// \param path File path to lookup
+/// \param id [out] Record identifier for this path on success
+/// \return 0 on success or an errno on failure
+INTERNAL int get_id(clink_db_t *db, const char *path, clink_record_id_t *id);

--- a/libclink/src/parse_with_clang.c
+++ b/libclink/src/parse_with_clang.c
@@ -61,9 +61,8 @@ typedef struct {
 
 } state_t;
 
-static int add_symbol(state_t *state, clink_category_t category,
-                      const char *name, const char *path, unsigned lineno,
-                      unsigned colno) {
+static int add(state_t *state, clink_category_t category, const char *name,
+               const char *path, unsigned lineno, unsigned colno) {
 
   assert(state != NULL);
 
@@ -478,7 +477,7 @@ static enum CXChildVisitResult visit(CXCursor cursor, CXCursor parent,
 
     } else {
       // add this symbol to the database
-      rc = add_symbol(state, category, name, fname, lineno, colno);
+      rc = add(state, category, name, fname, lineno, colno);
       if (ERROR(rc != 0))
         goto done;
 

--- a/libclink/src/parse_with_cscope.c
+++ b/libclink/src/parse_with_cscope.c
@@ -257,7 +257,7 @@ static int parse_into(clink_db_t *db, const char *cscope_out,
                       .parent = parent};
       if (pending_size == sizeof(pending) / sizeof(pending[0])) {
         // flush the pending symbols
-        if (ERROR((rc = add_symbols(db, pending_size, pending))))
+        if (ERROR((rc = add_symbols(db, pending_size, pending, -1))))
           goto done;
         pending_size = 0;
       }
@@ -276,7 +276,7 @@ static int parse_into(clink_db_t *db, const char *cscope_out,
 done:
   // flush any remaining pending symbols
   if (rc == 0 && pending_size > 0)
-    rc = add_symbols(db, pending_size, pending);
+    rc = add_symbols(db, pending_size, pending, -1);
 
   mmap_close(f);
 

--- a/libclink/src/parse_with_cscope.c
+++ b/libclink/src/parse_with_cscope.c
@@ -257,10 +257,7 @@ static int parse_into(clink_db_t *db, const char *cscope_out,
 
     if (in_file) {
       DEBUG("adding symbol \"%.*s\"", (int)symbol.size, symbol.base);
-      symbol_t sym = {.category = category,
-                      .name = symbol,
-                      .path = filename,
-                      .parent = parent};
+      symbol_t sym = {.category = category, .name = symbol, .parent = parent};
       if (pending_size == sizeof(pending) / sizeof(pending[0])) {
         // flush the pending symbols
         if (ERROR((rc = add_symbols(db, pending_size, pending, id))))

--- a/libclink/src/schema.sql
+++ b/libclink/src/schema.sql
@@ -1,11 +1,12 @@
 create table if not exists symbols (
   name text not null,
-  path text not null,
+  path integer not null,
   category integer not null,
   line integer not null,
   col integer not null,
   parent text,
-  unique(name, path, category, line, col));
+  unique(name, path, category, line, col),
+  foreign key(path) references records(id));
 
 create table if not exists content (
   path text not null,

--- a/libclink/src/schema.sql
+++ b/libclink/src/schema.sql
@@ -14,6 +14,7 @@ create table if not exists content (
   unique(path, line));
 
 create table if not exists records (
+  id integer primary key,
   path text not null unique,
   hash integer not null,
   timestamp integer not null);

--- a/libclink/src/vim_read_into.c
+++ b/libclink/src/vim_read_into.c
@@ -84,7 +84,9 @@ int clink_vim_read_into(clink_db_t *db, const char *filename) {
 
   // create a query to lookup relevant line numbers from the target file
   static const char QUERY[] =
-      "select distinct line from symbols where path = @filename order by line;";
+      "select distinct symbols.line from symbols inner join records "
+      "on symbols.path = records.id "
+      "where records.path = @filename order by symbols.line;";
   if (ERROR((rc = sql_prepare(db->db, QUERY, &s.stmt))))
     goto done;
   if (ERROR((rc = sql_bind_text(s.stmt, 1, filename))))

--- a/test/cases/atomic-builtins-2.c
+++ b/test/cases/atomic-builtins-2.c
@@ -6,5 +6,5 @@ int foo(void) {
 }
 
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
-// RUN: echo "select name, path, category, line, col from symbols where name = '__sync_fetch_and_add';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, col from symbols inner join records on symbols.path = records.id where symbols.name = '__sync_fetch_and_add';" | sqlite3 {%t}
 // CHECK: __sync_fetch_and_add|{%s}|1|5|10

--- a/test/cases/atomic-builtins.c
+++ b/test/cases/atomic-builtins.c
@@ -6,7 +6,7 @@ int foo(void) {
 }
 
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
-// RUN: echo "select name, path, line, col from symbols where name = '__ATOMIC_ACQUIRE';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.line, symbols.col from symbols inner join records on symbols.path = records.id where symbols.name = '__ATOMIC_ACQUIRE';" | sqlite3 {%t}
 // CHECK: __ATOMIC_ACQUIRE|{%s}|5|30
-// RUN: echo "select name, path, category, line, col from symbols where name = '__atomic_load_n';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col from symbols inner join records on symbols.path = records.id where symbols.name = '__atomic_load_n';" | sqlite3 {%t}
 // CHECK: __atomic_load_n|{%s}|1|5|10

--- a/test/cases/basic.py
+++ b/test/cases/basic.py
@@ -9,12 +9,12 @@ class Bar():
 
 # RUN: clink --build-only --database={%t} --debug {%s} >/dev/null
 
-# RUN: echo "select path, category, line, col from symbols where name = 'foo' and line < 12;" | sqlite3 {%t}
+# RUN: echo "select records.path, symbols.category, symbols.line, symbols.col from symbols inner join records on symbols.path = records.id where symbols.name = 'foo' and symbols.line < 12;" | sqlite3 {%t}
 # CHECK: {%s}|0|3|5
 
-# RUN: echo "select path, line, col from symbols where name = 'x' and line < 12 order by line;" | sqlite3 {%t}
+# RUN: echo "select records.path, symbols.line, symbols.col from symbols inner join records on symbols.path = records.id where symbols.name = 'x' and symbols.line < 12 order by symbols.line;" | sqlite3 {%t}
 # CHECK: {%s}|3|9
 # CHECK: {%s}|4|10
 
-# RUN: echo "select * from symbols where name = 'Bar' and line < 12;" | sqlite3 {%t}
+# RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col from symbols inner join records on symbols.path = records.id where symbols.name = 'Bar' and symbols.line < 12;" | sqlite3 {%t}
 # CHECK: Bar|{%s}|0|6|7

--- a/test/cases/cr.c
+++ b/test/cases/cr.c
@@ -6,14 +6,14 @@
 
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 
-// RUN: echo "select * from symbols where name = 'FOO';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'FOO';" | sqlite3 {%t}
 // CHECK: FOO|{%s}|0|3|9|
 
-// RUN: echo "select * from symbols where name = 'bar';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'bar';" | sqlite3 {%t}
 // CHECK: bar|{%s}|0|4|5|
 
-// RUN: echo "select * from symbols where name = 'baz';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'baz';" | sqlite3 {%t}
 // CHECK: baz|{%s}|0|7|9|
 
-// RUN: echo "select * from symbols where name = 'quz';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'quz';" | sqlite3 {%t}
 // CHECK: quz|{%s}|0|8|5|

--- a/test/cases/def-export.def
+++ b/test/cases/def-export.def
@@ -4,5 +4,5 @@ LIBRARY foo
 EXPORTS bar @1
 
 // RUN: clink --build-only --database={%t} --debug {%s} >/dev/null
-// RUN: echo "select * from symbols where name = 'bar' and line = 4;" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'bar' and symbols.line = 4;" | sqlite3 {%t}
 // CHECK: bar|{%s}|2|4|9|

--- a/test/cases/define-branch-0.c
+++ b/test/cases/define-branch-0.c
@@ -8,5 +8,5 @@
 
 // XFAIL: version.parse(os.environ["LLVM_VERSION"]) < version.parse("10.0.0")
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols where name = 'FOO';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'FOO';" | sqlite3 {%t}
 // CHECK: FOO|{%s}|0|5|9|

--- a/test/cases/define-branch-1.c
+++ b/test/cases/define-branch-1.c
@@ -6,5 +6,5 @@
 #endif
 
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols where name = 'FOO';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'FOO';" | sqlite3 {%t}
 // CHECK: FOO|{%s}|0|4|9|

--- a/test/cases/define-branch-elif-0.c
+++ b/test/cases/define-branch-elif-0.c
@@ -8,5 +8,5 @@
 
 // XFAIL: version.parse(os.environ["LLVM_VERSION"]) < version.parse("10.0.0")
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols where name = 'FOO';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'FOO';" | sqlite3 {%t}
 // CHECK: FOO|{%s}|0|6|9|

--- a/test/cases/define-branch-elif-1.c
+++ b/test/cases/define-branch-elif-1.c
@@ -6,5 +6,5 @@
 #endif
 
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols where name = 'FOO';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'FOO';" | sqlite3 {%t}
 // CHECK: FOO|{%s}|0|5|9|

--- a/test/cases/define-branch-else-0.c
+++ b/test/cases/define-branch-else-0.c
@@ -6,5 +6,5 @@
 #endif
 
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols where name = 'FOO';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'FOO';" | sqlite3 {%t}
 // CHECK: FOO|{%s}|0|5|9|

--- a/test/cases/define-branch-else-1.c
+++ b/test/cases/define-branch-else-1.c
@@ -8,5 +8,5 @@
 
 // XFAIL: version.parse(os.environ["LLVM_VERSION"]) < version.parse("10.0.0")
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols where name = 'FOO';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'FOO';" | sqlite3 {%t}
 // CHECK: FOO|{%s}|0|6|9|

--- a/test/cases/definition-multiplication.c
+++ b/test/cases/definition-multiplication.c
@@ -11,5 +11,5 @@ void foo(void) {
 }
 
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols where name = 'y' and line = 10;" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'y' and symbols.line = 10;" | sqlite3 {%t}
 // CHECK: y|{%s}|2|10|9|foo

--- a/test/cases/functions-in-scopes.c
+++ b/test/cases/functions-in-scopes.c
@@ -17,7 +17,7 @@ void foo(void) {
 }
 
 // RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols where category = 1 order by name;" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.category = 1 order by symbols.name;" | sqlite3 {%t}
 // CHECK: f|{%s}|1|11|7|foo
 // CHECK: g|{%s}|1|12|5|foo
 // CHECK: h|{%s}|1|13|9|foo

--- a/test/cases/global.c
+++ b/test/cases/global.c
@@ -1,5 +1,5 @@
 int x;
 
 // RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols;" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id;" | sqlite3 {%t}
 // CHECK: x|{%s}|0|1|5|

--- a/test/cases/global_const.c
+++ b/test/cases/global_const.c
@@ -1,5 +1,5 @@
 const int x;
 
 // RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols;" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id;" | sqlite3 {%t}
 // CHECK: x|{%s}|0|1|11|

--- a/test/cases/global_const2.c
+++ b/test/cases/global_const2.c
@@ -1,5 +1,5 @@
 int const x;
 
 // RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols;" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id;" | sqlite3 {%t}
 // CHECK: x|{%s}|0|1|11|

--- a/test/cases/ifdef.c
+++ b/test/cases/ifdef.c
@@ -11,15 +11,15 @@
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
 
 // can we recognise a reference in an ifdef?
-// RUN: echo "select * from symbols where name = 'FOO';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'FOO';" | sqlite3 {%t}
 // CHECK: FOO|{%s}|2|3|8|
 
 // can we reognise things in #ifs? 
-// RUN: echo "select * from symbols where name = 'QUX';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'QUX';" | sqlite3 {%t}
 // CHECK: QUX|{%s}|2|7|5|
-// RUN: echo "select * from symbols where name = 'QUUX';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'QUUX';" | sqlite3 {%t}
 // CHECK: QUUX|{%s}|2|7|12|
 
 // can we recognise things in #elifs?
-// RUN: echo "select * from symbols where name = 'QUUZ';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'QUUZ';" | sqlite3 {%t}
 // CHECK: QUUZ|{%s}|2|8|7|

--- a/test/cases/include.c
+++ b/test/cases/include.c
@@ -3,5 +3,5 @@
 #include "foo.h"
 
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols;" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id;" | sqlite3 {%t}
 // CHECK: foo.h|{%s}|3|3|1|

--- a/test/cases/include2.c
+++ b/test/cases/include2.c
@@ -3,5 +3,5 @@
 #include <foo.h>
 
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols;" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id;" | sqlite3 {%t}
 // CHECK: foo.h|{%s}|3|3|1|

--- a/test/cases/macro-definition-parent.c
+++ b/test/cases/macro-definition-parent.c
@@ -10,11 +10,11 @@
 
 // RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
 
-// RUN: echo "select * from symbols where name = 'ref';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'ref';" | sqlite3 {%t}
 // CHECK: ref|{%s}|2|4|13|FOO
 
-// RUN: echo "select * from symbols where name = 'a_call';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'a_call';" | sqlite3 {%t}
 // CHECK: a_call|{%s}|2|6|13|BAR
 
-// RUN: echo "select * from symbols where name = 'our_ref';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'our_ref';" | sqlite3 {%t}
 // CHECK: our_ref|{%s}|2|9|35|BAZ

--- a/test/cases/macro-definition.c
+++ b/test/cases/macro-definition.c
@@ -5,7 +5,7 @@
 #define BAZ(x) something_else(x)
 
 // RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols where category = 0 order by name;" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.category = 0 order by symbols.name;" | sqlite3 {%t}
 // CHECK: BAR|{%s}|0|4|9|
 // CHECK: BAZ|{%s}|0|5|9|
 // CHECK: FOO|{%s}|0|3|9|

--- a/test/cases/macro-parent.c
+++ b/test/cases/macro-parent.c
@@ -10,5 +10,5 @@ int foo() {
 }
 
 // RUN: clink --build-only --database={%t} --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols where name = 'macro_call' and category = 1;" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id where symbols.name = 'macro_call' and symbols.category = 1;" | sqlite3 {%t}
 // CHECK: macro_call|{%s}|1|8|3|foo

--- a/test/cases/other-builtins-2.c
+++ b/test/cases/other-builtins-2.c
@@ -5,5 +5,5 @@ void foo(void *dst, const void *src, unsigned len) {
 }
 
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
-// RUN: echo "select name, path, category, line, col from symbols where name = '__builtin_memcpy';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col from symbols inner join records on symbols.path = records.id where symbols.name = '__builtin_memcpy';" | sqlite3 {%t}
 // CHECK: __builtin_memcpy|{%s}|1|4|3

--- a/test/cases/other-builtins.c
+++ b/test/cases/other-builtins.c
@@ -6,5 +6,5 @@ void foo(void) {
 }
 
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
-// RUN: echo "select name, path, category, line, col from symbols where name = '__builtin_unreachable';" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col from symbols inner join records on symbols.path = records.id where symbols.name = '__builtin_unreachable';" | sqlite3 {%t}
 // CHECK: __builtin_unreachable|{%s}|1|5|3

--- a/test/cases/undef.c
+++ b/test/cases/undef.c
@@ -3,5 +3,5 @@
 #undef FOO
 
 // RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s} >/dev/null
-// RUN: echo "select * from symbols;" | sqlite3 {%t}
+// RUN: echo "select symbols.name, records.path, symbols.category, symbols.line, symbols.col, symbols.parent from symbols inner join records on symbols.path = records.id;" | sqlite3 {%t}
 // CHECK: FOO|{%s}|2|3|8|

--- a/test/db_add_record.c
+++ b/test/db_add_record.c
@@ -20,10 +20,12 @@ TEST("clink_db_add_record()") {
 
   // add a new record
   {
-    int rc = clink_db_add_record(db, "foo/bar.c", 42, 128);
+    clink_record_id_t id = -1;
+    int rc = clink_db_add_record(db, "foo/bar.c", 42, 128, &id);
     if (rc)
       fprintf(stderr, "clink_db_add_record: %s\n", strerror(rc));
     ASSERT_EQ(rc, 0);
+    ASSERT_GE(id, 0);
   }
 
   // close the database

--- a/test/db_add_symbol.c
+++ b/test/db_add_symbol.c
@@ -18,13 +18,20 @@ TEST("clink_db_add_symbol()") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add a new symbol
   {
     clink_symbol_t symbol = {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);

--- a/test/db_add_symbol_no_parent.c
+++ b/test/db_add_symbol_no_parent.c
@@ -18,13 +18,20 @@ TEST("clink_db_add_symbol() without a parent") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add a new symbol
   {
     clink_symbol_t symbol = {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
 
     int rc = clink_db_add_symbol(db, &symbol);
     if (rc)

--- a/test/db_find_call.c
+++ b/test/db_find_call.c
@@ -19,13 +19,20 @@ TEST("clink_db_find_call()") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add a new symbol
   {
     clink_symbol_t symbol = {
         .category = CLINK_FUNCTION_CALL, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -40,7 +47,7 @@ TEST("clink_db_find_call()") {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name2";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -55,7 +62,7 @@ TEST("clink_db_find_call()") {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name3";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent3";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -111,7 +118,7 @@ TEST("clink_db_find_call()") {
       ASSERT_STREQ(sym->name, "sym-name");
       ASSERT_EQ(sym->lineno, 42u);
       ASSERT_EQ(sym->colno, 10u);
-      ASSERT_STREQ(sym->path, "/foo/bar");
+      ASSERT_STREQ(sym->path, path);
       ASSERT_STREQ(sym->parent, "sym-parent");
     }
 

--- a/test/db_find_call_regex.c
+++ b/test/db_find_call_regex.c
@@ -19,13 +19,20 @@ TEST("clink_db_find_call() with a regex") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add a new symbol
   {
     clink_symbol_t symbol = {
         .category = CLINK_FUNCTION_CALL, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -40,7 +47,7 @@ TEST("clink_db_find_call() with a regex") {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name2";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -71,7 +78,7 @@ TEST("clink_db_find_call() with a regex") {
       ASSERT_STREQ(sym->name, "sym-name");
       ASSERT_EQ(sym->lineno, 42u);
       ASSERT_EQ(sym->colno, 10u);
-      ASSERT_STREQ(sym->path, "/foo/bar");
+      ASSERT_STREQ(sym->path, path);
       ASSERT_STREQ(sym->parent, "sym-parent");
     }
 

--- a/test/db_find_caller.c
+++ b/test/db_find_caller.c
@@ -19,13 +19,20 @@ TEST("clink_db_find_caller()") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add a new symbol
   {
     clink_symbol_t symbol = {
         .category = CLINK_FUNCTION_CALL, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -40,7 +47,7 @@ TEST("clink_db_find_caller()") {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name2";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -98,7 +105,7 @@ TEST("clink_db_find_caller()") {
       ASSERT_STREQ(sym->name, "sym-name");
       ASSERT_EQ(sym->lineno, 42u);
       ASSERT_EQ(sym->colno, 10u);
-      ASSERT_STREQ(sym->path, "/foo/bar");
+      ASSERT_STREQ(sym->path, path);
       ASSERT_STREQ(sym->parent, "sym-parent");
     }
 

--- a/test/db_find_caller_regex.c
+++ b/test/db_find_caller_regex.c
@@ -19,13 +19,20 @@ TEST("clink_db_find_caller() with a regex") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add a new symbol
   {
     clink_symbol_t symbol = {
         .category = CLINK_FUNCTION_CALL, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -40,7 +47,7 @@ TEST("clink_db_find_caller() with a regex") {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name2";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -71,7 +78,7 @@ TEST("clink_db_find_caller() with a regex") {
       ASSERT_STREQ(sym->name, "sym-name");
       ASSERT_EQ(sym->lineno, 42u);
       ASSERT_EQ(sym->colno, 10u);
-      ASSERT_STREQ(sym->path, "/foo/bar");
+      ASSERT_STREQ(sym->path, path);
       ASSERT_STREQ(sym->parent, "sym-parent");
     }
 

--- a/test/db_find_definition.c
+++ b/test/db_find_definition.c
@@ -19,13 +19,20 @@ TEST("clink_db_find_definition()") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add a new symbol
   {
     clink_symbol_t symbol = {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -40,7 +47,7 @@ TEST("clink_db_find_definition()") {
         .category = CLINK_INCLUDE, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name2";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -98,7 +105,7 @@ TEST("clink_db_find_definition()") {
       ASSERT_STREQ(sym->name, "sym-name");
       ASSERT_EQ(sym->lineno, 42u);
       ASSERT_EQ(sym->colno, 10u);
-      ASSERT_STREQ(sym->path, "/foo/bar");
+      ASSERT_STREQ(sym->path, path);
       ASSERT_STREQ(sym->parent, "sym-parent");
     }
 

--- a/test/db_find_definition_regex.c
+++ b/test/db_find_definition_regex.c
@@ -19,13 +19,20 @@ TEST("clink_db_find_definition() with a regex") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add a new symbol
   {
     clink_symbol_t symbol = {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -40,7 +47,7 @@ TEST("clink_db_find_definition() with a regex") {
         .category = CLINK_INCLUDE, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name2";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -71,7 +78,7 @@ TEST("clink_db_find_definition() with a regex") {
       ASSERT_STREQ(sym->name, "sym-name");
       ASSERT_EQ(sym->lineno, 42u);
       ASSERT_EQ(sym->colno, 10u);
-      ASSERT_STREQ(sym->path, "/foo/bar");
+      ASSERT_STREQ(sym->path, path);
       ASSERT_STREQ(sym->parent, "sym-parent");
     }
 

--- a/test/db_find_definition_regex2.c
+++ b/test/db_find_definition_regex2.c
@@ -20,13 +20,20 @@ TEST("ensure clink_db_find_definition() with a regex restricts to start and "
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add a new symbol
   {
     clink_symbol_t symbol = {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -41,7 +48,7 @@ TEST("ensure clink_db_find_definition() with a regex restricts to start and "
         .category = CLINK_INCLUDE, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name2";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -56,7 +63,7 @@ TEST("ensure clink_db_find_definition() with a regex restricts to start and "
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"another-sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -87,7 +94,7 @@ TEST("ensure clink_db_find_definition() with a regex restricts to start and "
       ASSERT_STREQ(sym->name, "sym-name");
       ASSERT_EQ(sym->lineno, 42u);
       ASSERT_EQ(sym->colno, 10u);
-      ASSERT_STREQ(sym->path, "/foo/bar");
+      ASSERT_STREQ(sym->path, path);
       ASSERT_STREQ(sym->parent, "sym-parent");
     }
 

--- a/test/db_find_includer.c
+++ b/test/db_find_includer.c
@@ -19,13 +19,20 @@ TEST("clink_db_find_includer()") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add a new symbol
   {
     clink_symbol_t symbol = {
         .category = CLINK_INCLUDE, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -40,7 +47,7 @@ TEST("clink_db_find_includer()") {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name2";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -96,7 +103,7 @@ TEST("clink_db_find_includer()") {
       ASSERT_STREQ(sym->name, "sym-name");
       ASSERT_EQ(sym->lineno, 42u);
       ASSERT_EQ(sym->colno, 10u);
-      ASSERT_STREQ(sym->path, "/foo/bar");
+      ASSERT_STREQ(sym->path, path);
       ASSERT_STREQ(sym->parent, "sym-parent");
     }
 

--- a/test/db_find_includer_regex.c
+++ b/test/db_find_includer_regex.c
@@ -19,13 +19,20 @@ TEST("clink_db_find_includer() with a regex") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add a new symbol
   {
     clink_symbol_t symbol = {
         .category = CLINK_INCLUDE, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -40,7 +47,7 @@ TEST("clink_db_find_includer() with a regex") {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name2";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -71,7 +78,7 @@ TEST("clink_db_find_includer() with a regex") {
       ASSERT_STREQ(sym->name, "sym-name");
       ASSERT_EQ(sym->lineno, 42u);
       ASSERT_EQ(sym->colno, 10u);
-      ASSERT_STREQ(sym->path, "/foo/bar");
+      ASSERT_STREQ(sym->path, path);
       ASSERT_STREQ(sym->parent, "sym-parent");
     }
 

--- a/test/db_find_includer_stem.c
+++ b/test/db_find_includer_stem.c
@@ -66,13 +66,20 @@ TEST("test looking up an included file by its final component works (1)") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add an include that is a path with multiple components
   {
     clink_symbol_t symbol = {
         .category = CLINK_INCLUDE, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"include/clink/clink.h";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -102,13 +109,20 @@ TEST("test looking up an included file by its final component works (2)") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add an include that is a path with multiple components
   {
     clink_symbol_t symbol = {
         .category = CLINK_INCLUDE, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"include/clink/clink.h";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -138,13 +152,20 @@ TEST("test looking up an included file by its final component works (3)") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add an include that is a path with multiple components
   {
     clink_symbol_t symbol = {
         .category = CLINK_INCLUDE, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"include/clink/clink.h";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);

--- a/test/db_find_record.c
+++ b/test/db_find_record.c
@@ -23,7 +23,7 @@ TEST("clink_db_find_record()") {
 
   // add a new record
   {
-    int rc = clink_db_add_record(db, "/foo/bar.c", 42, 128);
+    int rc = clink_db_add_record(db, "/foo/bar.c", 42, 128, NULL);
     if (rc)
       fprintf(stderr, "clink_db_add_record: %s\n", strerror(rc));
     ASSERT_EQ(rc, 0);

--- a/test/db_find_symbol.c
+++ b/test/db_find_symbol.c
@@ -19,13 +19,20 @@ TEST("clink_db_find_symbol()") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add a new symbol
   {
     clink_symbol_t symbol = {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -81,7 +88,7 @@ TEST("clink_db_find_symbol()") {
       ASSERT_STREQ(sym->name, "sym-name");
       ASSERT_EQ(sym->lineno, 42u);
       ASSERT_EQ(sym->colno, 10u);
-      ASSERT_STREQ(sym->path, "/foo/bar");
+      ASSERT_STREQ(sym->path, path);
       ASSERT_STREQ(sym->parent, "sym-parent");
     }
 

--- a/test/db_find_symbol_regex.c
+++ b/test/db_find_symbol_regex.c
@@ -19,13 +19,20 @@ TEST("clink_db_find_symbol() with a regex") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add a new symbol
   {
     clink_symbol_t symbol = {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -56,7 +63,7 @@ TEST("clink_db_find_symbol() with a regex") {
       ASSERT_STREQ(sym->name, "sym-name");
       ASSERT_EQ(sym->lineno, 42u);
       ASSERT_EQ(sym->colno, 10u);
-      ASSERT_STREQ(sym->path, "/foo/bar");
+      ASSERT_STREQ(sym->path, path);
       ASSERT_STREQ(sym->parent, "sym-parent");
     }
 

--- a/test/db_remove.c
+++ b/test/db_remove.c
@@ -18,13 +18,20 @@ TEST("clink_db_remove()") {
     ASSERT_EQ(rc, 0);
   }
 
+  // add a record for the upcoming path
+  char path[] = "/foo/bar";
+  {
+    int rc = clink_db_add_record(db, path, 0, 0, NULL);
+    ASSERT_EQ(rc, 0);
+  }
+
   // add a new symbol
   {
     clink_symbol_t symbol = {
         .category = CLINK_DEFINITION, .lineno = 42, .colno = 10};
 
     symbol.name = (char *)"sym-name";
-    symbol.path = (char *)"/foo/bar";
+    symbol.path = path;
     symbol.parent = (char *)"sym-parent";
 
     int rc = clink_db_add_symbol(db, &symbol);
@@ -34,7 +41,7 @@ TEST("clink_db_remove()") {
   }
 
   // remove the symbol we just added
-  clink_db_remove(db, "/foo/bar");
+  clink_db_remove(db, path);
 
   // close the database
   clink_db_close(&db);


### PR DESCRIPTION
This PR alters the database table `symbols` to, instead of having a path string in the `paths` column, have a foreign key to the `records` table. The effect of this is to reduce database size, accelerate insertion, and improve integrity checks.

Using a recent Graphviz checkout to profile, the PR has the following effect:
* database size 59797504B → 20934656B (-65%)
* database construction time 7.97s → 1.25s (-84%)