### PR TITLE
squash warnings on ignoring 'read' result

### DIFF
--- a/clink/src/screen.c
+++ b/clink/src/screen.c
@@ -273,7 +273,8 @@ event_t screen_read(void) {
     nfds_t nfds = sizeof(input) / sizeof(input[0]);
     if (poll(input, nfds, 0) > 0) {
       assert(more <= sizeof(buffer) / sizeof(buffer[0]) - 1);
-      (void)read(STDIN_FILENO, &buffer[1], more);
+      ssize_t ignored = read(STDIN_FILENO, &buffer[1], more);
+      (void)ignored;
     }
   }
 


### PR DESCRIPTION
Some combinations of GCC and Glibc seen to cause a -Wunused-result warning here.