### PR TITLE
CI: move clang-format to Clang 15

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,7 +51,7 @@ task:
 
     - name: C formatting
       container:
-        image: silkeh/clang
+        image: silkeh/clang:15
       install_script: apt-get update -y && apt-get install --no-install-recommends -y git
       test_script: clang-format --version && git ls-files -z -- ':!:test/cases' '**/*.c' '**/*.h' | xargs -0 -- clang-format --dry-run --style=file --Werror
 


### PR DESCRIPTION
Having this track latest is making this job unstable. It is currently failing due to updating to tip that has a different `clang-format` behaviour.