### PR TITLE
fix: retain query text when returning from Vim

### DIFF
--- a/clink/src/ui.c
+++ b/clink/src/ui.c
@@ -483,6 +483,7 @@ static void move_to_line(size_t target) {
 static void refresh(void) {
   screen_clear();
   print_menu();
+  move_to_line_no_blank(prompt_index);
   if (results.count > 0)
     print_results();
 }


### PR DESCRIPTION
Github: fixes #208 “when returning from editing a file, UI query area does not
Github:   repaint query text”