### PR TITLE
suppress duplicate results based only on visible fields

### DIFF
--- a/clink/src/ui.c
+++ b/clink/src/ui.c
@@ -92,13 +92,9 @@ static void print_colour(const char *str, const char *lock) {
 
 /// will these two symbols appear identically in the results list?
 static bool are_duplicates(const clink_symbol_t *a, const clink_symbol_t *b) {
-  if (LIKELY(strcmp(a->name, b->name) != 0))
-    return false;
   if (LIKELY(strcmp(a->path, b->path) != 0))
     return false;
   if (LIKELY(a->lineno != b->lineno))
-    return false;
-  if (LIKELY(a->colno != b->colno))
     return false;
   return true;
 }


### PR DESCRIPTION
The name of a symbol and its column location are not visible in UI search results. So when searching for something with multiple similar matches, results could appear as if they were duplicates of the adjacent rows. We now only show the first of such visually identical results.

Github: closes #205 “duplicate result rows when symbol appears multiple times”