### PR TITLE
CI: use default 'python3' on macOS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,8 +46,8 @@ task:
         CFLAGS: -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=undefined
         PATH: /opt/homebrew/opt/llvm/bin:${PATH}
         UBSAN_OPTIONS: print_stacktrace=1
-      install_script: brew update && brew install llvm && /opt/homebrew/Frameworks/Python.framework/Versions/3.11/bin/pip3 install pytest
-      test_script: ./misc/ci.sh
+      install_script: brew update && brew install llvm && python3 -m pip install pytest
+      test_script: env CMAKE_FLAGS=-DPython3_EXECUTABLE=$(which python3) ./misc/ci.sh
 
     - name: C formatting
       container:


### PR DESCRIPTION
For some reason we were calling Python 3.11, but CMake finds Python 3.12 causing it to fail to run the test suite later.