### PR TITLE
fix: do not ignore record insertion failure during DB construction

### DIFF
--- a/clink/src/build.c
+++ b/clink/src/build.c
@@ -282,7 +282,8 @@ static int process(unsigned long thread_id, pthread_t *threads, clink_db_t *db,
 
     // insert a new record for the file
     clink_record_id_t id = -1;
-    (void)clink_db_add_record(db, path, hash, timestamp, &id);
+    if (UNLIKELY((rc = clink_db_add_record(db, path, hash, timestamp, &id))))
+      break;
 
     if (UNLIKELY((rc = parse(thread_id, db, path, id))))
       break;

--- a/clink/src/help.c
+++ b/clink/src/help.c
@@ -80,7 +80,7 @@ int help(void) {
   }
 
   // wait for man to finish
-  (void)wait((int[]){0});
+  (void)wait(&(int){0});
 
   // cleanup
 done:

--- a/libclink/src/compiler_includes.c
+++ b/libclink/src/compiler_includes.c
@@ -185,8 +185,7 @@ int clink_compiler_includes(const char *compiler, char ***includes,
     child_err = NULL;
 
     // clean up the child
-    int ignored;
-    (void)waitpid(pid, &ignored, 0);
+    (void)waitpid(pid, &(int){0}, 0);
 
     // if we were successful, pass back what we discovered
     if (rc == 0) {


### PR DESCRIPTION
319369a9c7c650bc66877c7d9710876bf74fccfe introduced a variable (`id`) to the record addition that was then threaded through later functions without adjusting the `clink_db_add_record` call to account for the fact that using this when the call has failed is invalid.

Github: fixes #242 “assertion id >= 0 failed”
Reported-by: Timothy Madden