### PR TITLE
fix recognition of compile commands with rearranged arguments

### DIFF
--- a/clink/src/compile_commands_find.c
+++ b/clink/src/compile_commands_find.c
@@ -1,5 +1,6 @@
 #include "../../common/compiler.h"
 #include "compile_commands.h"
+#include "path.h"
 #include <assert.h>
 #include <clang-c/CXCompilationDatabase.h>
 #include <errno.h>
@@ -19,6 +20,25 @@ static bool is_cc(const char *path) {
     return true;
   if (strlen(path) >= 4 && strcmp(path + strlen(path) - 4, "/c++") == 0)
     return true;
+  return false;
+}
+
+/// does this look like a source file being passed to the compiler?
+static bool is_source_arg(const char *path) {
+  assert(path != NULL);
+
+  // does this look like a compiler flag?
+  if (path[0] == '-')
+    return false;
+
+  // does it look like a source file Clang would understand?
+  if (is_asm(path))
+    return true;
+  if (is_c(path))
+    return true;
+  if (is_cxx(path))
+    return true;
+
   return false;
 }
 
@@ -73,15 +93,6 @@ int compile_commands_find(compile_commands_t *cc, const char *source,
     }
   }
 
-  // only accept the command if its last parameter is the source itself
-  if (strcmp(av[ac - 1], source) != 0) {
-    rc = ENOMSG;
-    goto done;
-  }
-  free(av[ac - 1]);
-  av[ac - 1] = NULL;
-  --ac;
-
   // For some reason, libclang’s interface to the compilation database will
   // return hits for headers that do _not_ have specific compile commands in the
   // database. This is useful to us. Except that the returned command often does
@@ -89,18 +100,33 @@ int compile_commands_find(compile_commands_t *cc, const char *source,
   // not understand the argument separator (`--`) but then also uses the
   // argument separator in the command. When instructing libclang to parse using
   // this command, it then fails. See if we can detect that situation here and
-  // drop the `--`.
-  if (ac >= 2) {
-    do {
-      if (!is_cc(av[0]))
+  // drop the `--` and everything following.
+  if (is_cc(av[0])) {
+    for (size_t i = 1; i < ac; ++i) {
+      if (strcmp(av[i], "--") == 0) {
+        for (size_t j = i; j < ac; ++j) {
+          free(av[j]);
+          av[j] = NULL;
+        }
+        ac = i;
         break;
-
-      if (strcmp(av[ac - 1], "--") == 0) {
-        free(av[ac - 1]);
-        av[ac - 1] = NULL;
-        --ac;
       }
-    } while (0);
+    }
+  }
+
+  // Drop anything that looks like a source being passed to the compiler. We do
+  // this rather than more specific matching of `source` itself because the
+  // command may reference the source via a relative or symlink-containing path.
+  for (size_t i = 1; i < ac;) {
+    if (is_source_arg(av[i])) {
+      free(av[i]);
+      for (size_t j = i; j + 1 < ac; ++j)
+        av[j] = av[j + 1];
+      av[ac - 1] = NULL;
+      --ac;
+    } else {
+      ++i;
+    }
   }
 
   // success

--- a/test/integration.py
+++ b/test/integration.py
@@ -113,7 +113,6 @@ def test_case(tmp_path: Path, case: str):
     lit(tmp_path, Path(__file__).parent / "cases" / case)
 
 
-@pytest.mark.xfail(reason="https://github.com/Smattr/clink/issues/243", strict=True)
 def test_243(tmp_path: Path):
     """
     https://github.com/Smattr/clink/issues/243

--- a/test/integration.py
+++ b/test/integration.py
@@ -111,3 +111,54 @@ def test_case(tmp_path: Path, case: str):
     run Clink on the given test case and validate its CHECK lines
     """
     lit(tmp_path, Path(__file__).parent / "cases" / case)
+
+
+@pytest.mark.xfail(reason="https://github.com/Smattr/clink/issues/243", strict=True)
+def test_243(tmp_path: Path):
+    """
+    https://github.com/Smattr/clink/issues/243
+    Clink should not get confused by compile command argument ordering
+    """
+
+    # create a directory structure representative of typical compilation
+    src = tmp_path / "src"
+    src.mkdir()
+    build = tmp_path / "build"
+    build.mkdir()
+
+    # create an arbitrary source file
+    foo_c = src / "foo.c"
+    foo_c.write_text("int x;\n")
+
+    # create a compilation database with command line arguments unusually ordered
+    db = build / "compile_commands.json"
+    db.write_text(
+        f"""\
+    [
+      {{
+        "arguments": [
+          "gcc",
+          "-c",
+          "../src/foo.c",
+          "-o",
+          "foo.o"
+        ],
+        "directory": "f{build.absolute()}",
+        "file": "{foo_c.absolute()}"
+      }}
+    ]
+    """,
+        encoding="utf-8",
+    )
+
+    # run Clink on this working directory
+    stderr = subprocess.check_output(
+        ["clink", "--build-only", "--debug", "--jobs=1"],
+        cwd=tmp_path,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+    )
+
+    assert (
+        "no compile_commands.json entry found" not in stderr
+    ), "failed to find a compilation entry that exists"

--- a/test/integration.py
+++ b/test/integration.py
@@ -2,13 +2,13 @@
 Clink integration test suite
 """
 
-import os
+import os  # pylint: disable=unused-import
 import re
 import subprocess
 from pathlib import Path
 
 import pytest
-from packaging import version
+from packaging import version  # pylint: disable=unused-import
 
 
 def is_python(path: Path) -> bool:


### PR DESCRIPTION
The compilation database parsing code was written assuming the format:

```
  <compiler> … /path/to/source.c
    ▲            ▲
    │            └─ absolute path to source file
    └─ absolute or relative compiler path (“cc”, “/usr/bin/gcc”, …)
```

There was a minor quirk for “--” arguments, but this was sufficient to handle everything I have seen CMake produce. However, it appears differing argument lists can be written by other tools. Specifically the one that led to this issue looks like:

```
  <compiler> … ../foo/bar.c -o bar.o
                   ▲          ▲
                   │          └─ arguments following source path
                   └─ path not absolute
```

This is perfectly reasonable and well within the compilation database specification, but just not something I believed tools produced.

This fix attempts to be more agnostic to the arguments, both their form and the order in which they appear. We now drop “--” and everything following it as well as dropping anything that looks like a source file. This is subject to both false positives:

```
  cc -o bar.c …
         ▲
         └─ this will be incorrectly dropped, as it looks like a source
```

and false negatives:

```
  cc -x c my_source …
           ▲
           └─ this will be incorrectly kept, as it does not look like a source
```

but it seems enough to cope with reasonable imagined real world use cases.

Github: fixes https://github.com/Smattr/clink/issues/243
Reported-by: Timothy Madden