### PR TITLE
turn libclang survivable crashes into a warning

### DIFF
--- a/test/cases/atomic-crash.c
+++ b/test/cases/atomic-crash.c
@@ -3,5 +3,4 @@
 void foo(void);
 int x = __atomic_always_lock_free(2, foo);
 
-// XFAIL: version.parse("18.0.0") <= version.parse(os.environ["LLVM_VERSION"]) < version.parse("19.0.0")
-// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s}
+// RUN: env ASAN_OPTIONS=detect_leaks=0 clink --build-only --database={%t} --debug --parse-c=clang {%s}

--- a/test/cases/atomic-noderef.c
+++ b/test/cases/atomic-noderef.c
@@ -4,5 +4,5 @@
 
 int *_Atomic x __attribute__((noderef));
 
-// XFAIL: version.parse(os.environ["LLVM_VERSION"]) < version.parse("20.0.0")
-// RUN: {%timeout} 5s clink --build-only --database={%t} --debug --parse-c=clang {%s}
+// XFAIL: is_using_asan(shutil.which("clink")) and version.parse("18.0.0") <= version.parse(os.environ["LLVM_VERSION"]) < version.parse("19.0.0")
+// RUN: {%timeout} 5s env ASAN_OPTIONS=detect_leaks=0 clink --build-only --database={%t} --debug --parse-c=clang {%s}

--- a/test/cases/atomic-noderef.cc
+++ b/test/cases/atomic-noderef.cc
@@ -4,5 +4,5 @@
 
 int *_Atomic x __attribute__((noderef));
 
-// XFAIL: version.parse(os.environ["LLVM_VERSION"]) < version.parse("20.0.0")
-// RUN: {%timeout} 5s clink --build-only --database={%t} --debug --parse-cxx=clang {%s}
+// XFAIL: is_using_asan(shutil.which("clink")) and version.parse("18.0.0") <= version.parse(os.environ["LLVM_VERSION"]) < version.parse("19.0.0")
+// RUN: {%timeout} 5s env ASAN_OPTIONS=detect_leaks=0 clink --build-only --database={%t} --debug --parse-cxx=clang {%s}

--- a/test/cases/atomic-noderef2.cc
+++ b/test/cases/atomic-noderef2.cc
@@ -6,5 +6,4 @@ namespace {
 int *_Atomic x __attribute__((noderef));
 }
 
-// XFAIL: version.parse(os.environ["LLVM_VERSION"]) < version.parse("20.0.0")
-// RUN: clink --build-only --database={%t} --debug --parse-cxx=clang {%s}
+// RUN: env ASAN_OPTIONS=detect_leaks=0 clink --build-only --database={%t} --debug --parse-cxx=clang {%s}

--- a/test/cases/pragma-crash-clang.c
+++ b/test/cases/pragma-crash-clang.c
@@ -2,5 +2,4 @@
 
 #pragma clang __debug parser_crash
 
-// XFAIL: version.parse(os.environ["LLVM_VERSION"]) < version.parse("16.0.0")
-// RUN: clink --build-only --database={%t} --debug --parse-c=clang {%s}
+// RUN: env ASAN_OPTIONS=detect_leaks=0 clink --build-only --database={%t} --debug --parse-c=clang {%s}


### PR DESCRIPTION
This seems like a reasonable approach to an unknown outstanding set of LLVM bugs. This required a bit of finessing because ASan somehow turns some of these crashing scenarios into infinite loops.

This does not recover from every libclang crash. There are further uncaught crashes we cannot easily deal with such as failing an assertion or stack overflow.