### PR TITLE
add a test case of infinite looping on 'static_cast<foo>(::bar)'

### DIFF
--- a/test/cases/global-qualified.h
+++ b/test/cases/global-qualified.h
@@ -1,0 +1,6 @@
+/// does static cast of a globally qualified thing cause an infinite loop?
+
+void baz() { static_cast<foo>(::bar); }
+
+// XFAIL: version.parse(os.environ["LLVM_VERSION"]) >= version.parse("16.0.0")
+// RUN: {%timeout} 5s env ASAN_OPTIONS=detect_leaks=0 clink --build-only --database={%t} --debug --parse-c=clang --parse-cxx=clang {%s}

--- a/test/integration.py
+++ b/test/integration.py
@@ -121,7 +121,7 @@ root = Path(__file__).parent / "cases"
 cases = sorted(
     x.name
     for x in root.iterdir()
-    if x.suffix in (".c", ".cc", ".def", ".l", ".py", ".td", ".y")
+    if x.suffix in (".c", ".cc", ".def", ".h", ".l", ".py", ".td", ".y")
 )
 
 


### PR DESCRIPTION
Github: #269 “handle libclang looping”